### PR TITLE
Remove "Console.Readkey()" from code...

### DIFF
--- a/local.dbaid.checkmk/Program.cs
+++ b/local.dbaid.checkmk/Program.cs
@@ -188,9 +188,7 @@ namespace local.dbaid.checkmk
                     return 2;
                 }
             }
-#if (DEBUG)
-            Console.ReadKey();
-#endif
+
             //Added improves performance, no requirement to maintain pools once application exits, GC overhead 1-2 seconds
             System.Data.SqlClient.SqlConnection.ClearAllPools();
             return 1;


### PR DESCRIPTION
Where did that come from? Not added by developer; assuming VS being too smart for its own good.