### PR TITLE
Release 6.4.4

### DIFF
--- a/dbaid.common/Properties/AssemblyInfo.cs
+++ b/dbaid.common/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.3")]
+[assembly: AssemblyVersion("6.4.4")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.checkmk/App.config
+++ b/local.dbaid.checkmk/App.config
@@ -21,9 +21,6 @@
     -->
   </checkCache>
   <startup>
-    <supportedRuntime version="v4.8" />
-    <supportedRuntime version="v4.7" />
-    <supportedRuntime version="v4.5" />
     <supportedRuntime version="v4.0" />
   </startup>
   <system.web>

--- a/local.dbaid.checkmk/App.config.release
+++ b/local.dbaid.checkmk/App.config.release
@@ -20,9 +20,6 @@
     -->
   </checkCache>
   <startup>
-    <supportedRuntime version="v4.8" />
-    <supportedRuntime version="v4.7" />
-	<supportedRuntime version="v4.5" />
 	<supportedRuntime version="v4.0" />
   </startup>
 </configuration>

--- a/local.dbaid.checkmk/Properties/AssemblyInfo.cs
+++ b/local.dbaid.checkmk/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.3")]
+[assembly: AssemblyVersion("6.4.4")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -150,9 +150,19 @@ try {
         [string]$StatusDetails = ""
         [string]$State = ""
 
-        foreach ($ckrow in $ckDataSet.Tables[0].Rows) {
-            $StatusDetails += $ckrow.message + ";\n "
-            $State = $ckrow.state
+        <# this loop concatenates row message data into one message. #>
+        <# NB - for backups, need to have data on one line otherwise it can't be pulled into DOME (only the first line comes through). #>
+        if ($ckproc -eq "[check].[backup]") {
+            foreach ($ckrow in $ckDataSet.Tables[0].Rows) {
+                $StatusDetails += $ckrow.message + "| "
+                $State = $ckrow.state
+            }
+        }
+        else {
+            foreach ($ckrow in $ckDataSet.Tables[0].Rows) {
+                $StatusDetails += $ckrow.message + ";\n "
+                $State = $ckrow.state
+            }
         }
 
         <#  Write output for Checkmk agent to consume.  #>

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -69,7 +69,7 @@
 #>
 Param(
     [parameter(Mandatory=$false)]
-    [string[]]$SqlServer = @("Data Source=127.0.0.1;","Data Source=127.0.0.1,49999;")
+    [string[]]$SqlServer = @("Data Source=localhost;")
 )
 Set-Location $PSScriptRoot
 

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -97,7 +97,7 @@ try {
     #>
 
     <#  Check if this is a clustered SQL instance. #>
-    $IsClustered = Invoke-SqlCmd -ConnectionString $ConnectionString -Query "SELECT CAST(SERVERPROPERTY('IsClustered') AS bit) AS [IsClustered]"
+    $IsClustered = Invoke-SqlCmd -ConnectionString $ConnectionString -Query "SELECT CAST(SERVERPROPERTY('IsClustered') AS tinyint) AS [IsClustered]"
         
     <#  Get NetBIOS name according to SQL Server. I.e. computer name that SQL instance is running on.  #>
     $NetBIOSName = Invoke-SqlCmd -ConnectionString $ConnectionString -Query "SELECT SERVERPROPERTY('ComputerNamePhysicalNetBIOS') AS [NetBIOSName]"
@@ -106,6 +106,7 @@ try {
     $ComputerName = $env:computername
 
     <#  If computer name & NetBIOS name don't match and SQL instance is clustered, this script is running on the passive node for this SQL instance; so don't run the SQL checks, they'll be run on the active node.  #>
+    <#  NB - Machine account for each node needs to have its own login in SQL Server and rights to _dbaid database (admin & monitor roles). #>
     if ($ComputerName.ToUpper() -ne $NetBIOSName.NetBIOSName.ToUpper() -and $IsClustered.IsClustered -eq 1) {
         continue
     }

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -152,7 +152,7 @@ try {
 
         <# this loop concatenates row message data into one message. #>
         <# NB - for backups, need to have data on one line otherwise it can't be pulled into DOME (only the first line comes through). #>
-        if ($ckproc -eq "[check].[backup]") {
+        if ($ckproc -eq "[check].[backup]") || ($ckproc -eq "[check].[inventory]"){
             foreach ($ckrow in $ckDataSet.Tables[0].Rows) {
                 $StatusDetails += $ckrow.message + "| "
                 $State = $ckrow.state

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -252,6 +252,10 @@ try {
             $row++
         }
 
+        if ($State = "") {
+            $State = "OK"
+        }
+
         <#  Write output for Checkmk agent to consume.  #>
         Write-Host "$Status mssql_$($ServiceName)_$($InstanceName) $StatusDetails $State"
     }

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -45,8 +45,9 @@ Sub Main()
         ' open conection to database
         v_SQL_Conn.Open v_DB_Connect_String
 
-        ' query to check if SQL is clustered
-        v_SQL_Query = "SELECT CAST(SERVERPROPERTY('IsClustered') AS bit) AS [IsClustered]"
+        ' query to check if SQL is clustered. Have to CAST to tinyint rather than bit as VBS doesn't understand bit
+        ' NB - Machine account for each node needs to have its own login in SQL Server and rights to _dbaid database (admin & monitor roles).
+        v_SQL_Query = "SELECT CAST(SERVERPROPERTY('IsClustered') AS tinyint) AS [IsClustered]"
 
         ' populate recordset
         ' parameters 3 & 4: 0=forward-only cursor (moot if only 1 row returned), 1=read-only records
@@ -71,7 +72,7 @@ Sub Main()
         v_RecordSet.Close
 
         ' If computer name & NetBIOS name don't match and SQL instance is clustered, this script is running on the passive node for this SQL instance; so don't run the SQL checks, they'll be run on the active node.
-        If UCase(v_NetBiosName) <> UCase(v_HostName) AND ABS(v_IsClustered) = 1 Then
+        If UCase(v_NetBiosName) <> UCase(v_HostName) AND v_IsClustered = 1 Then
             Exit Sub
         End If
 

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -139,8 +139,8 @@ Sub Main()
                 Do While (Not v_SQLChecks_RecordSet.EOF)
                     ' this loop concatenates row message data into one message. 
                     ' also capture the number of rows via incrementing count (since RecordSet.RecordCount doesn't work properly and returns -1)
-                    ' NB - for backups, need to have data on one line otherwise it can't be pulled into DOME (only the first line comes through).
-                    If v_RecordSet.Fields.Item("proc") = "[check].[backup]" Then
+                    ' NB - for backups & inventory, need to have data on one line otherwise it can't be pulled into DOME (only the first line comes through).
+                    If (v_RecordSet.Fields.Item("proc") = "[check].[backup]") Or (v_RecordSet.Fields.Item("proc") = "[check].[inventory]") Then
                         v_SQLChecks_Message = v_SQLChecks_Message & v_SQLChecks_RecordSet.Fields.Item("message") & "|"
                         v_SQLChecks_Count = v_SQLChecks_Count + 1
                         v_SQLChecks_RecordSet.MoveNext

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -1,7 +1,7 @@
 Sub Main()
     ' define list of instances to connect to. Array elements should take the form of "MachineName" or "MachineName\InstanceName" (default & named instances respectively) where MachineName can be the hostname or IP address of the server . Optionally, add ",<TCPPort>".
     Dim v_SQLInstances
-    v_SQLInstances = Array("127.0.0.1", "127.0.0.1\SQL2017,49999", "127.0.0.1,49998")
+    v_SQLInstances = Array("localhost")
 
     ' declare variables
     Dim v_DB_Connect_String

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -137,12 +137,18 @@ Sub Main()
                 End Select
 
                 Do While (Not v_SQLChecks_RecordSet.EOF)
-                    ' this loop concatenates row message data into one line. 
-                    ' E.g., when there are multiple databases that have missed backups, the procedure returns a multi-row table, not just a single row like some others.
+                    ' this loop concatenates row message data into one message. 
                     ' also capture the number of rows via incrementing count (since RecordSet.RecordCount doesn't work properly and returns -1)
-                    v_SQLChecks_Message = v_SQLChecks_Message & v_SQLChecks_RecordSet.Fields.Item("message") & ";\n "
-                    v_SQLChecks_Count = v_SQLChecks_Count + 1
-                    v_SQLChecks_RecordSet.MoveNext
+                    ' NB - for backups, need to have data on one line otherwise it can't be pulled into DOME (only the first line comes through).
+                    If v_RecordSet.Fields.Item("proc") = "[check].[backup]" Then
+                        v_SQLChecks_Message = v_SQLChecks_Message & v_SQLChecks_RecordSet.Fields.Item("message") & "|"
+                        v_SQLChecks_Count = v_SQLChecks_Count + 1
+                        v_SQLChecks_RecordSet.MoveNext
+                    Else
+                        v_SQLChecks_Message = v_SQLChecks_Message & v_SQLChecks_RecordSet.Fields.Item("message") & ";\n "
+                        v_SQLChecks_Count = v_SQLChecks_Count + 1
+                        v_SQLChecks_RecordSet.MoveNext
+                    End If
                 Loop
                 
                 ' If the top row returned has [state] value of "NA", then set count=0 (i.e. monitor doesn't apply, nothing wrong detected). If there's more than one row returned, there's probably a fault.

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -265,6 +265,10 @@ Sub Main()
                     v_SQLChecks_RecordSet.MoveNext
                 Loop
 
+				If v_SQLChecks_StateCheck = "" Then
+					v_SQLChecks_StateCheck = "OK"
+				End If
+				
                 ' Write output for Checkmk agent to consume.
                 WScript.Echo v_SQLChecks_Status & " mssql_" & v_SQLChecks_CheckName & "_" & v_InstanceName & " " & v_SQLChecks_Message & " " & v_SQLChecks_StateCheck
 

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -71,7 +71,7 @@ Sub Main()
         v_RecordSet.Close
 
         ' If computer name & NetBIOS name don't match and SQL instance is clustered, this script is running on the passive node for this SQL instance; so don't run the SQL checks, they'll be run on the active node.
-        If UCase(v_NetBiosName) <> UCase(v_HostName) AND v_IsClustered = 1 Then
+        If UCase(v_NetBiosName) <> UCase(v_HostName) AND ABS(v_IsClustered) = 1 Then
             Exit Sub
         End If
 

--- a/local.dbaid.collector/App.config
+++ b/local.dbaid.collector/App.config
@@ -22,9 +22,6 @@
 		<add key="default_cmd_timeout_sec" value="30" />
 	</appSettings>
 	<startup>
-		<supportedRuntime version="v4.8" />
-		<supportedRuntime version="v4.7" />
-		<supportedRuntime version="v4.5" />
 		<supportedRuntime version="v4.0" />
 	</startup>
 </configuration>

--- a/local.dbaid.collector/App.config.release
+++ b/local.dbaid.collector/App.config.release
@@ -22,9 +22,6 @@
     <add key="default_cmd_timeout_sec" value="30" />
   </appSettings>
   <startup>
-	  <supportedRuntime version="v4.8" />
-	  <supportedRuntime version="v4.7" />
-	  <supportedRuntime version="v4.5" />
 	  <supportedRuntime version="v4.0" />
   </startup>
 </configuration>

--- a/local.dbaid.collector/Properties/AssemblyInfo.cs
+++ b/local.dbaid.collector/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.3")]
+[assembly: AssemblyVersion("6.4.4")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.configg/App.config
+++ b/local.dbaid.configg/App.config
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <startup>
-	  <supportedRuntime version="v4.8" />
-	  <supportedRuntime version="v4.7" />
-	  <supportedRuntime version="v4.5" />
 	  <supportedRuntime version="v4.0" />
   </startup>
 </configuration>

--- a/local.dbaid.configg/Properties/AssemblyInfo.cs
+++ b/local.dbaid.configg/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.3")]
+[assembly: AssemblyVersion("6.4.4")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.database/Database/Function/dbo_get_instance_version.sql
+++ b/local.dbaid.database/Database/Function/dbo_get_instance_version.sql
@@ -9,8 +9,9 @@ AS
 BEGIN
     DECLARE @edition nvarchar(4000),
             @patch_level sysname;
-    SELECT @edition = CAST(SERVERPROPERTY('MachineName') AS sysname) + N'\' + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER') + N',Microsoft SQL Server ' + REPLACE(REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Edition') AS sysname), N'(64-bit)', N'64-bit'), N': Core-based Licensing', N''), N'Edition', N''), N'  ', N' ')
-           ,@patch_level = CAST(SERVERPROPERTY('ProductLevel') AS sysname) + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductUpdateLevel') AS sysname), N'') + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductBuildType') AS sysname), N'') + N',' + CAST(SERVERPROPERTY('ProductVersion') AS sysname);
+    SELECT @edition = CAST([Value] AS sysname) + N',' + CAST(SERVERPROPERTY('MachineName') AS sysname) + N'\' + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER') + N',Microsoft SQL Server ' + REPLACE(REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Edition') AS sysname), N'(64-bit)', N'64-bit'), N': Core-based Licensing', N''), N'Edition', N''), N'  ', N' ')
+           ,@patch_level = CAST(SERVERPROPERTY('ProductLevel') AS sysname) + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductUpdateLevel') AS sysname), N'') + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductBuildType') AS sysname), N'') + N',' + CAST(SERVERPROPERTY('ProductVersion') AS sysname)
+    FROM [dbo].[static_parameters] WHERE [name] = N'TENANT_NAME';
 
 	INSERT INTO @output
         SELECT N'0 mssql_' 

--- a/local.dbaid.database/Database/Function/dbo_get_instance_version.sql
+++ b/local.dbaid.database/Database/Function/dbo_get_instance_version.sql
@@ -9,7 +9,7 @@ AS
 BEGIN
     DECLARE @edition nvarchar(4000),
             @patch_level sysname;
-    SELECT @edition = CAST([Value] AS sysname) 
+    SELECT @edition = CAST([value] AS sysname) 
            + N',' 
            + CAST(SERVERPROPERTY('MachineName') AS sysname) 
            + N'\' 

--- a/local.dbaid.database/Database/Function/dbo_get_instance_version.sql
+++ b/local.dbaid.database/Database/Function/dbo_get_instance_version.sql
@@ -9,8 +9,28 @@ AS
 BEGIN
     DECLARE @edition nvarchar(4000),
             @patch_level sysname;
-    SELECT @edition = CAST([Value] AS sysname) + N',' + CAST(SERVERPROPERTY('MachineName') AS sysname) + N'\' + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER') + N',Microsoft SQL Server ' + REPLACE(REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Edition') AS sysname), N'(64-bit)', N'64-bit'), N': Core-based Licensing', N''), N'Edition', N''), N'  ', N' ')
-           ,@patch_level = CAST(SERVERPROPERTY('ProductLevel') AS sysname) + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductUpdateLevel') AS sysname), N'') + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductBuildType') AS sysname), N'') + N',' + CAST(SERVERPROPERTY('ProductVersion') AS sysname)
+    SELECT @edition = CAST([Value] AS sysname) 
+           + N',' 
+           + CAST(SERVERPROPERTY('MachineName') AS sysname) 
+           + N'\' 
+           + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER') 
+           + N',Microsoft SQL Server '
+           + CASE LEFT(CAST(SERVERPROPERTY('ProductVersion') AS sysname), 4)
+               WHEN N'15.0' THEN N'2019 '
+               WHEN N'14.0' THEN N'2017 '
+               WHEN N'13.0' THEN N'2016 '
+               WHEN N'12.0' THEN N'2014 '
+               WHEN N'11.0' THEN N'2012 '
+               WHEN N'10.5' THEN N'2008 R2 '
+               WHEN N'10.0' THEN N'2008 '
+               WHEN N'9.0.' THEN N'2005 '
+               WHEN N'8.0.' THEN N'2000 '
+             END
+           + REPLACE(REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Edition') AS sysname), N'(64-bit)', N'64-bit'), N': Core-based Licensing', N''), N'Edition', N''), N'  ', N' ')
+           ,@patch_level = CAST(SERVERPROPERTY('ProductLevel') AS sysname) 
+           + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductUpdateLevel') AS sysname), N'') 
+           + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductBuildType') AS sysname), N'') + N',' 
+           + CAST(SERVERPROPERTY('ProductVersion') AS sysname)
     FROM [dbo].[static_parameters] WHERE [name] = N'TENANT_NAME';
 
 	INSERT INTO @output

--- a/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Databases.sql
+++ b/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Databases.sql
@@ -39,8 +39,8 @@ BEGIN
         If database is NOT OFFLINE and monitoring [is_enabled] is False, include as it is assumed planned outage or similar to prevent alerts. It should still appear for CMDB reconciliation. If not, set CI to Non Discoverable in CMDB.
         If database id NOT OFFLINE and monitoring [is_enabled] is True, include it as this is the status quo for normal operation.
     */
-    WHERE (db.[state_desc] IN ('OFFLINE') AND c.[is_enabled] = 1)
-       OR (db.[state_desc] NOT IN ('OFFLINE'))
+    WHERE (db.[state_desc] IN (N'OFFLINE') AND c.[is_enabled] = 1)
+       OR (db.[state_desc] NOT IN (N'OFFLINE'))
     GROUP BY db.[name], db.[owner_sid], db.[database_id], db.[create_date], db.[state_desc], db.[is_read_only], db.[recovery_model_desc], db.[collation_name], db.[compatibility_level];
      
     IF (SELECT [value] FROM [$(DatabaseName)].[dbo].[static_parameters] WHERE [name] = 'PROGRAM_NAME') = PROGRAM_NAME()

--- a/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Databases.sql
+++ b/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Databases.sql
@@ -7,26 +7,46 @@ Version 3, 29 June 2007
 CREATE PROCEDURE [deprecated].[Databases]
 WITH ENCRYPTION
 AS
-SET NOCOUNT ON;
+BEGIN
+    SET NOCOUNT ON;
 
-EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
+    EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
 
-DECLARE @client varchar(128)
-select @client = replace(replace(replace(CAST(serverproperty('servername') as varchar(128))+[setting],'@','_'),'.','_'),'\','#')  from [deprecated].[tbparameters] where [parametername] = 'Client_domain'
+    DECLARE @client varchar(128);
 
-select @client as 'Client', Getdate() as 'Checkdate',db.[name], CAST(ROUND(SUM(CAST([size] AS bigint))/128.00, 2) AS NUMERIC(20,2)) as size, 
- isnull(suser_sname(db.owner_sid),'~~UNKNOWN~~') as owner,
-  db.database_id as dbid ,
-  db.create_date as Created ,
-  'Status ='+convert(sysname,db.state_desc) +'| Updateability='+ Case db.is_read_only when 0 then 'READ_WRITE' else 'READ_ONLY' end +
-   '| Recovery='+convert(sysname,db.[recovery_model_desc] )+ '| Collation='+convert(sysname,isnull(db.[collation_name], convert(sysname,serverproperty('Collation')))) COLLATE DATABASE_DEFAULT as  [Status] ,
-   db.[compatibility_level] as Compatailiity_level 
-     from sys.databases db join sys.master_files mf on mf.database_id = db.database_id
-     INNER JOIN [_dbaid].[dbo].[config_database] c ON db.database_id = c.database_id
-     WHERE db.[state_desc] <> 'OFFLINE'
-     group by db.name, db.owner_sid, db.database_id, db.create_date, db.state_desc, db.is_read_only, db.[recovery_model_desc], db.[collation_name],  db.[compatibility_level]
+    SELECT @client = REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Servername') AS varchar(128)) + [setting], '@', '_'), '.', '_'), '\', '#')
+    FROM [$(DatabaseName)].[deprecated].[tbparameters] 
+    WHERE [parametername] = 'Client_domain';
+
+    SELECT @client AS [Client]
+            ,GETDATE() AS [Checkdate]
+            ,db.[name]
+            ,CAST(ROUND(SUM(CAST([size] AS bigint))/128.00, 2) AS NUMERIC(20,2)) AS [size]
+            ,ISNULL(SUSER_SNAME(db.[owner_sid]), '~~UNKNOWN~~') AS [owner]
+            ,db.[database_id] AS [dbid]
+            ,db.[create_date] AS [Created]
+            ,'Status =' + CONVERT(sysname, db.[state_desc]) 
+                + '| Updateability=' + CASE db.[is_read_only] WHEN 0 THEN 'READ_WRITE' ELSE 'READ_ONLY' END 
+                + '| Recovery=' + CONVERT(sysname, db.[recovery_model_desc] )
+                + '| Collation=' + CONVERT(sysname, ISNULL(db.[collation_name], CONVERT(sysname, SERVERPROPERTY('Collation')))) COLLATE DATABASE_DEFAULT AS [Status]
+            ,db.[compatibility_level] AS [Compatailiity_level]
+    FROM sys.databases db 
+      INNER JOIN sys.master_files mf ON mf.database_id = db.database_id
+      INNER JOIN [$(DatabaseName)].[dbo].[config_database] c ON db.database_id = c.database_id
+    /* Logic for SACM CMDB reconciliation:
+        If database is OFFLINE and monitoring [is_enabled] is False, don't include as it is assumed planned outage/pending decommission. Update CMDB.
+        If database is OFFLINE and monitoring [is_enabled] is True, include as it is assumed there's a problem (which is why the database is OFFLINE) or someone hasn't updated monitoring & CMDB for a decommission.
+        If database is NOT OFFLINE and monitoring [is_enabled] is False, include as it is assumed planned outage or similar to prevent alerts. It should still appear for CMDB reconciliation. If not, set CI to Non Discoverable in CMDB.
+        If database id NOT OFFLINE and monitoring [is_enabled] is True, include it as this is the status quo for normal operation.
+    */
+    WHERE (db.[state_desc] IN ('OFFLINE') AND c.[is_enabled] = 1)
+       OR (db.[state_desc] NOT IN ('OFFLINE'))
+    GROUP BY db.[name], db.[owner_sid], db.[database_id], db.[create_date], db.[state_desc], db.[is_read_only], db.[recovery_model_desc], db.[collation_name], db.[compatibility_level];
      
-	IF (SELECT [value] FROM [dbo].[static_parameters] WHERE [name] = 'PROGRAM_NAME') = PROGRAM_NAME()
-		UPDATE [dbo].[procedure] SET [last_execution_datetime] = GETDATE() WHERE [procedure_id] = @@PROCID;
+    IF (SELECT [value] FROM [$(DatabaseName)].[dbo].[static_parameters] WHERE [name] = 'PROGRAM_NAME') = PROGRAM_NAME()
+	    UPDATE [$(DatabaseName)].[dbo].[procedure] 
+        SET [last_execution_datetime] = GETDATE() 
+        WHERE [procedure_id] = @@PROCID;
 
-REVERT;
+    REVERT;
+END

--- a/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Databases.sql
+++ b/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Databases.sql
@@ -23,7 +23,7 @@ select @client as 'Client', Getdate() as 'Checkdate',db.[name], CAST(ROUND(SUM(C
    db.[compatibility_level] as Compatailiity_level 
      from sys.databases db join sys.master_files mf on mf.database_id = db.database_id
      INNER JOIN [_dbaid].[dbo].[config_database] c ON db.database_id = c.database_id
-     WHERE c.[is_enabled] = 1
+     WHERE db.[state_desc] <> 'OFFLINE'
      group by db.name, db.owner_sid, db.database_id, db.create_date, db.state_desc, db.is_read_only, db.[recovery_model_desc], db.[collation_name],  db.[compatibility_level]
      
 	IF (SELECT [value] FROM [dbo].[static_parameters] WHERE [name] = 'PROGRAM_NAME') = PROGRAM_NAME()

--- a/local.dbaid.database/Database/Procedure/check/chart_capacity_combined.sql
+++ b/local.dbaid.database/Database/Procedure/check/chart_capacity_combined.sql
@@ -26,15 +26,17 @@ BEGIN
     IF EXISTS (SELECT TABLE_NAME FROM tempdb.INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME LIKE N'#apollodblist%')
       DROP TABLE #apollodblist;
 
-    CREATE TABLE #apollofilesizesraw ([database_id] int, [file_id] int, [data_space_id] int, [drive] nchar(1), [file_size_kb] decimal(20,2), [drive_size_kb] decimal(20,2));
-    CREATE TABLE #apollofileusedraw ([file_used_kb] decimal(20,2), [drive] char(1));
-    CREATE TABLE #apollosizesmonitoroutput ([drive] nchar(1), [file_size_total_kb] decimal(20,2), [file_used_total_kb] decimal(20,2), [drive_size_kb] decimal(20,2));
+    CREATE TABLE #apollofilesizesraw ([database_id] int, [file_id] int, [data_space_id] int, [drive] nchar(1), [file_size_b] decimal(20,2), [drive_size_b] decimal(20,2));
+    CREATE TABLE #apollofileusedraw ([file_used_b] decimal(20,2), [drive] char(1));
+    CREATE TABLE #apollosizesmonitoroutput ([drive] nchar(1), [file_size_total_b] decimal(20,2), [file_used_total_b] decimal(20,2), [drive_size_b] decimal(20,2));
     CREATE TABLE #apollodblist ([database_id] int, [name] sysname);
 
-    -- get list of online databases that we can connect to (i.e. not aag secondary replicas)
-    -- could use [sys].[availability_replicas].[is_primary_replica] if SQL 2012 DMV had that column :(
-    -- this procedure not really intended to be run against DR replicas; disks should be configured the same as prod anyway.
-    -- still, we don't want this procedure to just fail.
+    /* 
+       get list of online databases that we can connect to (i.e. not aag secondary replicas)
+       could use [sys].[availability_replicas].[is_primary_replica] if SQL 2012 DMV had that column :(
+       this procedure not really intended to be run against DR replicas; disks should be configured the same as prod anyway.
+       still, we don't want this procedure to just fail.
+    */
     INSERT INTO #apollodblist ([database_id], [name])
       SELECT d.[database_id], d.[name]
       FROM sys.databases d
@@ -47,9 +49,11 @@ BEGIN
                                       AND ar.[secondary_role_allow_connections_desc] = N'NO'
                                       AND ars.[role_desc] = N'SECONDARY');
                                   
-    -- get sizes of all database files
-    -- using loop to go through each database as master.sys.master_files doesn't always have correct values,
-    --   especially for tempdb (it seems to show sizes tempdb is configured to startup with and doesn't increase when autogrowth occurs).
+    /* 
+       get sizes of all database files
+       using loop to go through each database as master.sys.master_files doesn't always have correct values,
+         especially for tempdb (it seems to show sizes tempdb is configured to startup with and doesn't increase when autogrowth occurs).
+    */
     DECLARE cursor0 CURSOR FAST_FORWARD FOR
       SELECT [name] FROM #apollodblist;
 
@@ -60,17 +64,17 @@ BEGIN
     WHILE @@FETCH_STATUS = 0
     BEGIN
       SELECT @sql = N'/* get database file sizes */
-      ;WITH CTE ([database_id], [file_id], [data_space_id], [drive], [file_size_kb])
+      ;WITH CTE ([database_id], [file_id], [data_space_id], [drive], [file_size_b])
       AS
       (
-        SELECT DB_ID(' + QUOTENAME(@dbname, '''') + N') AS "database_id", [file_id], [data_space_id], LEFT([physical_name], 1) AS "drive", CONVERT(decimal(20,2), [size]) * 8 AS "file_size_kb"
+        SELECT DB_ID(' + QUOTENAME(@dbname, '''') + N') AS "database_id", [file_id], [data_space_id], LEFT([physical_name], 1) AS "drive", (CONVERT(decimal(20,2), [size]) * 8) * 1024 AS "file_size_b"
         FROM ' + QUOTENAME(@dbname) + N'.sys.database_files
       )
-      SELECT c.[database_id], c.[file_id], c.[data_space_id], c.[drive], c.[file_size_kb]
+      SELECT c.[database_id], c.[file_id], c.[data_space_id], c.[drive], c.[file_size_b]
       FROM CTE c
         INNER JOIN #apollodblist d ON c.[database_id] = d.[database_id];'
       
-      INSERT INTO #apollofilesizesraw ([database_id], [file_id], [data_space_id], [drive], [file_size_kb])
+      INSERT INTO #apollofilesizesraw ([database_id], [file_id], [data_space_id], [drive], [file_size_b])
         EXEC sp_executesql @sql;
 
       FETCH cursor0 INTO @dbname;
@@ -79,12 +83,14 @@ BEGIN
     CLOSE cursor0;
     DEALLOCATE cursor0;
     
-    -- total combined file sizes per drive
-    INSERT INTO #apollosizesmonitoroutput ([drive], [file_size_total_kb])
-      SELECT [drive], SUM(file_size_kb) AS "file_sizes" FROM #apollofilesizesraw GROUP BY [drive] ORDER BY [drive];
+    /* total combined file sizes per drive */
+    INSERT INTO #apollosizesmonitoroutput ([drive], [file_size_total_b])
+      SELECT [drive], SUM(file_size_b) AS "file_sizes" FROM #apollofilesizesraw GROUP BY [drive] ORDER BY [drive];
 
-    -- get size of each drive used by SQL data files
-    -- only need to find one db file per drive in order to call sys.dm_os_volume_stats to get drive size
+    /* 
+       get size of each drive used by SQL data files
+       only need to find one db file per drive in order to call sys.dm_os_volume_stats to get drive size
+    */
     ;WITH CTE ([rownum], [database_id], [file_id], [drive])
     AS
     (
@@ -92,14 +98,16 @@ BEGIN
       FROM #apollofilesizesraw
     )
     UPDATE #apollosizesmonitoroutput
-    SET [drive_size_kb] = CAST(dovs.[total_bytes]/1024.0 AS decimal(20,2))
+    SET [drive_size_b] = CAST(dovs.[total_bytes] AS decimal(20,2))
     FROM CTE 
       CROSS APPLY sys.dm_os_volume_stats([database_id], [file_id]) dovs
       INNER JOIN #apollosizesmonitoroutput ao ON ao.[drive] = CTE.[drive]
     WHERE [rownum] = 1;
 
-    -- For each database, get space used per database file
-    -- Exclude Always On Availability Group non-readable secondary replicas (can't connect to them)
+    /* 
+       For each database, get space used per database file
+       Exclude Always On Availability Group non-readable secondary replicas (can't connect to them)
+    */
     DECLARE cursor1 CURSOR FAST_FORWARD FOR
       SELECT [name] FROM #apollodblist;
 
@@ -110,7 +118,7 @@ BEGIN
     WHILE @@FETCH_STATUS = 0
     BEGIN
       SELECT @sql = N'/* get transaction log space used */
-      SELECT lsu.[used_log_space_in_bytes] / 1024.0 AS "file_used_kb", LEFT(mf.[physical_name], 1) AS "drive"
+      SELECT lsu.[used_log_space_in_bytes] AS "file_used_b", LEFT(mf.[physical_name], 1) AS "drive"
       FROM ' + QUOTENAME(@dbname) + N'.sys.dm_db_log_space_usage lsu
         INNER JOIN sys.master_files mf ON lsu.[database_id] = mf.[database_id] AND mf.[type_desc] = ''LOG'';';
 
@@ -118,7 +126,7 @@ BEGIN
         EXEC sp_executesql @sql;
 
       SELECT @sql = N'/* get data file space used */
-      SELECT fsu.[allocated_extent_page_count] * 8 AS "file_used_kb", LEFT(mf.[physical_name], 1) AS "drive"
+      SELECT (fsu.[allocated_extent_page_count] * 8) * 1024 AS "file_used_b", LEFT(mf.[physical_name], 1) AS "drive"
       FROM ' + QUOTENAME(@dbname) + N'.sys.dm_db_file_space_usage fsu
         INNER JOIN sys.master_files mf ON fsu.[database_id] = mf.[database_id] AND fsu.[file_id] = mf.[file_id];';
 
@@ -131,24 +139,26 @@ BEGIN
     CLOSE cursor1;
     DEALLOCATE cursor1;
 
-    -- get combined total of space used within data files per drive
+    /* get combined total of space used within data files per drive */
     ;WITH CTE AS
     (
-      SELECT [drive], SUM([file_used_kb]) AS "file_used_total_kb"
+      SELECT [drive], SUM([file_used_b]) AS "file_used_total_b"
       FROM #apollofileusedraw
       GROUP BY [drive]
     )
     UPDATE #apollosizesmonitoroutput
-    SET [file_used_total_kb] = CTE.[file_used_total_kb]
+    SET [file_used_total_b] = CTE.[file_used_total_b]
     FROM CTE
       INNER JOIN #apollosizesmonitoroutput ao ON ao.[drive] = CTE.[drive];
 
-    -- format for dbaid.checkmk.exe plugin to understand
-    -- "value" = combined file space used, "warning" = combined file sizes, "critical" = drive size, "max" = combined drive size + 5% to force PNP4Nagios to display critical value
-    SELECT [file_used_total_kb] AS "val",
-           [file_size_total_kb] AS "warn",
-           [drive_size_kb] AS "crit",
-           QUOTENAME([drive], '''') + N'=' + CAST([file_used_total_kb] AS nvarchar(20)) + N';' + CAST([file_size_total_kb] AS nvarchar(20)) + N';' + CAST([drive_size_kb] AS nvarchar(20)) + N';0;' + CAST(CAST([drive_size_kb]*1.05 AS decimal(20,2)) AS nvarchar(20)) AS "pnp" 
+   /*
+       format for dbaid.checkmk.exe plugin to understand
+       "value" = combined file space used, "warning" = combined file sizes, "critical" = drive size, "max" = combined drive size + 5% to force PNP4Nagios to display critical value
+   */
+   SELECT [file_used_total_b] AS "val",
+           [file_size_total_b] AS "warn",
+           [drive_size_b] AS "crit",
+           QUOTENAME([drive], '''') + N'=' + CAST([file_used_total_b] AS nvarchar(20)) + N';' + CAST([file_size_total_b] AS nvarchar(20)) + N';' + CAST([drive_size_b] AS nvarchar(20)) + N';0;' + CAST(CAST([drive_size_b]*1.05 AS decimal(20,2)) AS nvarchar(20)) AS "pnp" 
     FROM #apollosizesmonitoroutput;
 
 

--- a/local.dbaid.database/Database/Procedure/check/check_backup.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_backup.sql
@@ -15,8 +15,11 @@ SET NOCOUNT ON;
 
 	DECLARE @to_backup INT;
 	DECLARE @not_backup INT;
+	DECLARE @tenant NVARCHAR(256);
+  
+  SELECT @tenant = CAST([value] AS nvarchar(256)) FROM [$(DatabaseName)].[dbo].[static_parameters] WHERE [name] = N'TENANT_NAME';
 
-	EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
+  EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
 
 	IF SERVERPROPERTY('IsHadrEnabled') = 1
 	BEGIN
@@ -96,11 +99,11 @@ SET NOCOUNT ON;
 			+ ISNULL(CAST(CAST(DATEDIFF(HOUR, [B].[backup_finish_date], GETDATE()) / [D].[backup_frequency_hours] AS INT) AS VARCHAR(5)), ''ALL'')
 			,[S].[state]
 		FROM Backups [B]
-			INNER JOIN [dbo].[config_database] [D]
+			INNER JOIN [$(DatabaseName)].[dbo].[config_database] [D]
 				ON [B].[database_id] = [D].[database_id]
 			LEFT JOIN @ag_table AS [AGT]
 				ON [AGT].[database_id] = [D].[database_id] 
-			LEFT JOIN [dbo].[config_alwayson] [ca]
+			LEFT JOIN [$(DatabaseName)].[dbo].[config_alwayson] [ca]
 				ON [AGT].[ag_id] = [ca].[ag_id]
 			CROSS APPLY (SELECT CASE WHEN ([B].[backup_finish_date] IS NULL OR DATEDIFF(HOUR, [B].[backup_finish_date], GETDATE()) > ([D].[backup_frequency_hours])) THEN [D].[backup_state_alert] ELSE N''OK'' END AS [state]) [S]
 		WHERE [B].[row] = 1
@@ -122,8 +125,8 @@ SET NOCOUNT ON;
 	END
 	ELSE
 	BEGIN
-		SELECT @to_backup=COUNT(*) FROM [dbo].[config_database] WHERE [backup_frequency_hours] > 0 AND LOWER([db_name]) NOT IN (N'tempdb') AND [is_enabled] = 1
-		SELECT @not_backup=COUNT(*) FROM [dbo].[config_database] WHERE [backup_frequency_hours] = 0 AND LOWER([db_name]) NOT IN (N'tempdb') OR [is_enabled] = 0
+		SELECT @to_backup=COUNT(*) FROM [$(DatabaseName)].[dbo].[config_database] WHERE [backup_frequency_hours] > 0 AND LOWER([db_name]) NOT IN (N'tempdb') AND [is_enabled] = 1
+		SELECT @not_backup=COUNT(*) FROM [$(DatabaseName)].[dbo].[config_database] WHERE [backup_frequency_hours] = 0 AND LOWER([db_name]) NOT IN (N'tempdb') OR [is_enabled] = 0
 
 		;WITH Backups
 		AS
@@ -142,24 +145,21 @@ SET NOCOUNT ON;
 				AND [D].[is_in_standby] = 0
 		)
 		INSERT INTO @check
-		SELECT N'database=' 
-				+ QUOTENAME([D].[db_name])
-				+ N'; last_backup=' 
-				+ ISNULL(REPLACE(CONVERT(NVARCHAR(20), [B].[backup_finish_date], 120), N' ', N'T'), N'NEVER')
-				+ N'; type=' 
-				+ CASE [type] WHEN 'D' THEN 'FULL' WHEN 'I' THEN 'DIFFERENTIAL' ELSE 'UNKNOWN' END
-				+ N'; backups_missed=' 
-				+ ISNULL(CAST(CAST(DATEDIFF(HOUR, [B].[backup_finish_date], GETDATE()) / [D].[backup_frequency_hours] AS INT) AS VARCHAR(5)), 'ALL')
-			,[S].[state]
+		SELECT @tenant
+				+ N',' + CAST(SERVERPROPERTY('MachineName') AS sysname) + N'\' + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER')
+				+ N',' + QUOTENAME([D].[db_name])
+				+ N',' + ISNULL(CONVERT(NVARCHAR(20), [B].[backup_finish_date], 23), N'1900-01-01')
+				+ N',' + CASE [type] WHEN 'D' THEN 'FULL' WHEN 'I' THEN 'DIFFERENTIAL' ELSE 'UNKNOWN' END
+				,[S].[state]
 		FROM Backups [B]
-			INNER JOIN [dbo].[config_database] [D]
+			INNER JOIN [$(DatabaseName)].[dbo].[config_database] [D]
 				ON [B].[database_id] = [D].[database_id]
 			CROSS APPLY (SELECT CASE WHEN ([B].[backup_finish_date] IS NULL OR DATEDIFF(HOUR, [B].[backup_finish_date], GETDATE()) > ([D].[backup_frequency_hours])) THEN [D].[backup_state_alert] ELSE N'OK' END AS [state]) [S]
 		WHERE [B].[row] = 1
 			AND [D].[backup_frequency_hours] > 0
-			AND DATEDIFF(HOUR, [B].[create_date], GETDATE()) > [D].[backup_frequency_hours]
+			--AND DATEDIFF(HOUR, [B].[create_date], GETDATE()) > [D].[backup_frequency_hours]
 			AND LOWER([D].[db_name]) NOT IN (N'tempdb')
-			AND [S].[state] NOT IN (N'OK')
+			--AND [S].[state] NOT IN (N'OK')
 			AND [D].[is_enabled] = 1
 		ORDER BY [D].[db_name]
 
@@ -172,3 +172,5 @@ SET NOCOUNT ON;
 
 	REVERT;
 END
+
+

--- a/local.dbaid.database/Database/Procedure/check/check_backup.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_backup.sql
@@ -146,8 +146,9 @@ SET NOCOUNT ON;
 		)
 		INSERT INTO @check
 		SELECT @tenant
-				+ N',' + CAST(SERVERPROPERTY('MachineName') AS sysname) + N'\' + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER')
-				+ N',' + QUOTENAME([D].[db_name])
+				+ N',' + CAST(SERVERPROPERTY('MachineName') AS sysname) 
+				+ N'\' + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER')
+				+ N'\' + [D].[db_name]
 				+ N',' + ISNULL(CONVERT(NVARCHAR(20), [B].[backup_finish_date], 23), N'1900-01-01')
 				+ N',' + CASE [type] WHEN 'D' THEN 'FULL' WHEN 'I' THEN 'DIFFERENTIAL' ELSE 'UNKNOWN' END
 				,[S].[state]

--- a/local.dbaid.database/Database/Procedure/check/check_database.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_database.sql
@@ -16,7 +16,7 @@ BEGIN
 						,[state] NVARCHAR(8));
 	
 	DECLARE @onlinecount INT;
-	DECLARE @redstorecount INT;
+	DECLARE @restorecount INT;
 	DECLARE @recovercount INT;
 
 	SELECT @onlinecount = COUNT(*)
@@ -26,7 +26,7 @@ BEGIN
 	WHERE [C].[is_enabled] = 1
 		AND [D].[state] IN (0);
 
-	SELECT @redstorecount = COUNT(*)
+	SELECT @restorecount = COUNT(*)
 	FROM [sys].[databases] [D]
 		INNER JOIN [dbo].[config_database] [C] 
 			ON [D].[database_id] = [C].[database_id]
@@ -54,7 +54,7 @@ BEGIN
 
 		IF (SELECT COUNT(*) FROM @check) < 1
 			INSERT INTO @check 
-			VALUES(CAST(@onlinecount AS NVARCHAR(10)) + N' online, ' + CAST(@redstorecount AS NVARCHAR(10)) + N' restoring, ' + CAST(@recovercount AS NVARCHAR(10)) + N' recovering.'
+			VALUES(CAST(@onlinecount AS NVARCHAR(10)) + N' online, ' + CAST(@restorecount AS NVARCHAR(10)) + N' restoring, ' + CAST(@recovercount AS NVARCHAR(10)) + N' recovering.'
 				,N'NA');
 
 		SELECT [message], [state] FROM @check

--- a/local.dbaid.database/Database/Procedure/check/check_inventory.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_inventory.sql
@@ -1,0 +1,53 @@
+﻿/*
+Copyright (C) 2015 Datacom
+GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+*/
+
+CREATE PROCEDURE [check].[inventory]
+WITH ENCRYPTION
+AS
+BEGIN
+	SET NOCOUNT ON;
+	
+	EXECUTE AS LOGIN = N'$(DatabaseName)';
+
+	DECLARE @check TABLE([message] NVARCHAR(4000)
+						,[state] NVARCHAR(8));
+
+    INSERT INTO @check
+    SELECT CAST(s.[Value] AS sysname) 
+            + N',' 
+            + CAST(SERVERPROPERTY('MachineName') AS sysname) 
+            + N'\' 
+            + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER') 
+            + N'\' + D.[name]
+            + N',Microsoft SQL Server '
+            + CASE LEFT(CAST(SERVERPROPERTY('ProductVersion') AS sysname), 4)
+                WHEN N'15.0' THEN N'2019 '
+                WHEN N'14.0' THEN N'2017 '
+                WHEN N'13.0' THEN N'2016 '
+                WHEN N'12.0' THEN N'2014 '
+                WHEN N'11.0' THEN N'2012 '
+                WHEN N'10.5' THEN N'2008 R2 '
+                WHEN N'10.0' THEN N'2008 '
+                WHEN N'9.0.' THEN N'2005 '
+                WHEN N'8.0.' THEN N'2000 '
+            END
+            + REPLACE(REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Edition') AS sysname), N'(64-bit)', N'64-bit'), N': Core-based Licensing', N''), N'Edition', N''), N'  ', N' ')
+            + N',' + CAST(SERVERPROPERTY('ProductLevel') AS sysname) 
+            + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductUpdateLevel') AS sysname), N'') 
+            + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductBuildType') AS sysname), N'') 
+            , N'OK'
+    FROM [dbo].[static_parameters] s, sys.databases D 
+    WHERE s.[name] = N'TENANT_NAME'
+    /* exclude system databases & _dbaid as none of these are loaded into CMDB */
+    AND D.[name] NOT IN ('_dbaid', 'master', 'model', 'msdb', 'tempdb');
+
+    SELECT [message], [state] FROM @check;
+
+	REVERT;
+END
+
+
+

--- a/local.dbaid.database/PreUpgrade.sql
+++ b/local.dbaid.database/PreUpgrade.sql
@@ -67,10 +67,5 @@ BEGIN
 		EXEC sp_executesql @stmt=@backupsql;
 	END
 
-	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_backup_static_parameters]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[static_parameters]') IS NOT NULL)
-	BEGIN
-		SET @backupsql = N'SELECT * INTO [tempdb].[dbo].[$(DatabaseName)_backup_static_parameters] FROM [$(DatabaseName)].[dbo].[static_parameters]';
-		EXEC sp_executesql @stmt = @backupsql;
-	END
 END
 GO

--- a/local.dbaid.database/PreUpgrade.sql
+++ b/local.dbaid.database/PreUpgrade.sql
@@ -13,58 +13,64 @@ BEGIN
 		EXEC sp_executesql @stmt=@backupsql;
 	END
 
-	IF (OBJECT_ID(N'tempdb.dbo.$(DatabaseName)_deprecated_tbparameters') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[deprecated].[tbparameters]') IS NOT NULL)
+	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_deprecated_tbparameters]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[deprecated].[tbparameters]') IS NOT NULL)
 	BEGIN
 		SET @backupsql = N'SELECT [parametername],[setting],[status],[comments] INTO [tempdb].[dbo].[$(DatabaseName)_deprecated_tbparameters] FROM [$(DatabaseName)].[deprecated].[tbparameters]';
 		EXEC sp_executesql @stmt=@backupsql;
 	END
 
-	IF (OBJECT_ID(N'tempdb.dbo.$(DatabaseName)_backup_config_alwayson') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[config_alwayson]') IS NOT NULL)
+	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_backup_config_alwayson]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[config_alwayson]') IS NOT NULL)
 	BEGIN
 		SET @backupsql = N'SELECT [ag_id],[ag_name],[ag_state_alert],[ag_state_is_enabled],[ag_role],[ag_role_alert],[ag_role_is_enabled] INTO [tempdb].[dbo].[$(DatabaseName)_backup_config_alwayson] FROM [$(DatabaseName)].[dbo].[config_alwayson]';
 		EXEC sp_executesql @stmt=@backupsql;
 	END
 
-	IF (OBJECT_ID(N'tempdb.dbo.$(DatabaseName)_backup_config_database') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[config_database]') IS NOT NULL)
+	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_backup_config_database]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[config_database]') IS NOT NULL)
 	BEGIN
 		SET @backupsql = N'SELECT * INTO [tempdb].[dbo].[$(DatabaseName)_backup_config_database] FROM [$(DatabaseName)].[dbo].[config_database]';
 		EXEC sp_executesql @stmt=@backupsql;
 	END
 
-	IF (OBJECT_ID(N'tempdb.dbo.$(DatabaseName)_backup_config_login_failures') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[config_login_failures]') IS NOT NULL)
+	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_backup_config_login_failures]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[config_login_failures]') IS NOT NULL)
 	BEGIN
 		SET @backupsql = N'SELECT * INTO [tempdb].[dbo].[$(DatabaseName)_backup_config_login_failures] FROM [$(DatabaseName)].[dbo].[config_login_failures]';
 		EXEC sp_executesql @stmt=@backupsql;
 	END
 
-	IF (OBJECT_ID(N'tempdb.dbo.$(DatabaseName)_backup_config_job') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[config_job]') IS NOT NULL)
+	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_backup_config_job]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[config_job]') IS NOT NULL)
 	BEGIN
 		SET @backupsql = N'SELECT * INTO [tempdb].[dbo].[$(DatabaseName)_backup_config_job] FROM [$(DatabaseName)].[dbo].[config_job]';
 		EXEC sp_executesql @stmt=@backupsql;
 	END
 
-	IF (OBJECT_ID(N'tempdb.dbo.$(DatabaseName)_backup_config_perfcounter') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[config_perfcounter]') IS NOT NULL)
+	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_backup_config_perfcounter]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[config_perfcounter]') IS NOT NULL)
 	BEGIN
 		SET @backupsql = N'SELECT * INTO [tempdb].[dbo].[$(DatabaseName)_backup_config_perfcounter] FROM [$(DatabaseName)].[dbo].[config_perfcounter]';
 		EXEC sp_executesql @stmt=@backupsql;
 	END
 
-	IF (OBJECT_ID(N'tempdb.dbo.$(DatabaseName)_backup_static_parameters') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[static_parameters]') IS NOT NULL)
+	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_backup_static_parameters]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[static_parameters]') IS NOT NULL)
 	BEGIN
 		SET @backupsql = N'SELECT * INTO [tempdb].[dbo].[$(DatabaseName)_backup_static_parameters] FROM [$(DatabaseName)].[dbo].[static_parameters] WHERE [name] NOT IN (''PUBLIC_ENCRYPTION_KEY'')';
 		EXEC sp_executesql @stmt=@backupsql;
 	END
 
-	IF (OBJECT_ID(N'tempdb.dbo.$(DatabaseName)_backup_version') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[version]') IS NOT NULL)
+	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_backup_version]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[version]') IS NOT NULL)
 	BEGIN
 		SET @backupsql = N'SELECT * INTO [tempdb].[dbo].[$(DatabaseName)_backup_version] FROM [$(DatabaseName)].[dbo].[version]';
 		EXEC sp_executesql @stmt=@backupsql;
 	END
 
-	IF (OBJECT_ID(N'tempdb.dbo.$(DatabaseName)_backup_procedure') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[procedure]') IS NOT NULL)
+	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_backup_procedure]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[procedure]') IS NOT NULL)
 	BEGIN
 		SET @backupsql = N'SELECT * INTO [tempdb].[dbo].[$(DatabaseName)_backup_procedure] FROM [$(DatabaseName)].[dbo].[procedure]';
 		EXEC sp_executesql @stmt=@backupsql;
+	END
+
+	IF (OBJECT_ID(N'tempdb.dbo.[$(DatabaseName)_backup_static_parameters]') IS NULL AND OBJECT_ID(N'[$(DatabaseName)].[dbo].[static_parameters]') IS NOT NULL)
+	BEGIN
+		SET @backupsql = N'SELECT * INTO [tempdb].[dbo].[$(DatabaseName)_backup_static_parameters] FROM [$(DatabaseName)].[dbo].[static_parameters]';
+		EXEC sp_executesql @stmt = @backupsql;
 	END
 END
 GO

--- a/local.dbaid.database/deployDBAid.ps1
+++ b/local.dbaid.database/deployDBAid.ps1
@@ -20,6 +20,7 @@
 $deploy_collector = 1                        # deploy dbaid collector: 1 = Yes, 0 = No
 $deploy_configg = 1                          # deploy config genie: 1 = Yes, 0 = No
 $deploy_checkmk = 1                          # deploy checkmk plugin: 1 = Yes, 0 = No
+# future enhancement: option to deploy checkmk exe, vbs, or ps1 plugin (vbs or ps1 preferred)
 $hostname = $env:computername                # If this is a clustered SQL instance, change this to $hostname = "<VNN of SQL instance>"
 $SQLInstance = "MSSQLSERVER"                 # SQL instance to deploy to. MSSQLSERVER = default instance.
 $dbaid_db_name = "_dbaid"                    # Name of database to deploy dbaid to. Best if this is left as default of _dbaid

--- a/local.dbaid.database/deployDBAid.ps1
+++ b/local.dbaid.database/deployDBAid.ps1
@@ -3,13 +3,14 @@
 #
 # Expected source folder structure example:
 # 
-# C:\temp\DBAid-build-6.4.0
+# C:\temp\DBAid-build-6.4.4
 #        \check_mk
 #        \database
 #        \Datacom
 #        \DBAid
 #
-# Root folder can be different, but the 4 subfolders must remain the same.
+# Root folder can be different, (just update $SourceRootFolder below), 
+#   but the 4 subfolders must remain the same.
 #
 # Not tested with clusters. Intended for standalone instances.
 #
@@ -23,10 +24,10 @@ $hostname = $env:computername                # If this is a clustered SQL instan
 $SQLInstance = "MSSQLSERVER"                 # SQL instance to deploy to. MSSQLSERVER = default instance.
 $dbaid_db_name = "_dbaid"                    # Name of database to deploy dbaid to. Best if this is left as default of _dbaid
 $SourceRootFolder = "C:\temp"                # Folder in which source DBAid folder structure is in
-$DBAid_src = "$SourceRootFolder\DBAid-build-6.4.0" # Root folder for dbaid source files.
+$DBAid_src = "$SourceRootFolder\DBAid-build-6.4.4" # Root folder for dbaid source files.
 $dest_root = "C:"                            # Root drive to deploy dbaid executables to.
 
-$checkmk_svc = "NT AUTHORITY\SYSTEM"         # Service account to use for CheckMK plugin (should be same as Check_MK_Agent Windows service)
+$checkmk_svc = "NT AUTHORITY\SYSTEM"         # Service account to use for Checkmk plugin (should be same as Check_MK_Agent Windows service)
 $collector_svc = "NT AUTHORITY\SYSTEM"       # Service account to use for dbaid.collector. Only required if not running dbaid.collector from SQL Agent.
 $client_domain = "@domain.co.nz"             # Domain name (FQDN) client machine is in
 $publickey = "<RSAKeyValue><Modulus>blahblahblah</Modulus><Exponent>KFLR</Exponent></RSAKeyValue>"
@@ -34,6 +35,7 @@ $EmailEnable = "false"                       # Collector to email files? true/fa
 $EmailSmtp = "mailhost.domain.co.nz"         # Mail relay host for sending emails
 $EmailTo = "recipient@domain.co.nz"          # Who to send collector files to
 $EmailFrom = "$hostname@domain.co.nz"        # Who the collector files came from (usually <hostname|VNN@domain.co.nz)
+$Tenant = "Tenant"                           # Customer/tenant/site being monitored. Stored in [dbo].[static_parameters] table. Used in Checkmk monitors to identify configuration items.
 
 # set standard destination folders
 $collector_dest = "$dest_root\DBAid"                       # Folder for dbaid.collector.
@@ -322,9 +324,10 @@ try{
 
   # set client domain
   # NB - looks for default values to replace. If you've changed the defaults, they won't get updated.
-  $content = ($content) -Replace(":setvar ClientDomain `"@datacom.co.nz`"",":setvar ClientDomain `"$client_domain`"")
+  $content = ($content) -Replace(":setvar ClientDomain `"@domain.co.nz`"",":setvar ClientDomain `"$client_domain`"")
   $content = ($content) -Replace(":setvar DatabaseName `"_dbaid`"",":setvar DatabaseName `"$dbaid_db_name`"")
   $content = ($content) -Replace(":setvar ServiceLoadExe `"_dbaid`"",":setvar ServiceLoadExe `"$configg_dest\dbaid.configg.exe`"")
+  $content = ($content) -Replace(":setvar Tenant `"Tenant`"",":setvar Tenant `"$Tenant`"")
 
   # update file
   $content | Set-Content $DBAid_db_src -Encoding UTF8

--- a/local.dbaid.database/deployDBAid.ps1
+++ b/local.dbaid.database/deployDBAid.ps1
@@ -316,7 +316,7 @@ try {
       $content = ($content).Replace($currentserverliststring, $newserverliststring)
 
       # save changes to plugin script
-      $content | Set-Content "$checkmk_dest\$checkmk_vbscript" -Encoding UTF8
+      $content | Set-Content "$checkmk_dest\$checkmk_vbscript" -Encoding ASCII
     }
     else {
       # copy plugin script
@@ -329,7 +329,7 @@ try {
       $content = ($content).Replace("v_SQLInstances = Array(`"localhost`")","v_SQLInstances = Array($servername)")
       
       # save changes to plugin script
-      $content | Set-Content "$checkmk_dest\$checkmk_vbscript" -Encoding UTF8
+      $content | Set-Content "$checkmk_dest\$checkmk_vbscript" -Encoding ASCII
       
     }
     

--- a/local.dbaid.database/local.dbaid.database.sqlproj
+++ b/local.dbaid.database/local.dbaid.database.sqlproj
@@ -280,8 +280,12 @@
       <DefaultValue>C:\Datacom\dbaid.configg.exe</DefaultValue>
       <Value>$(SqlCmdVar__16)</Value>
     </SqlCmdVariable>
+    <SqlCmdVariable Include="Tenant">
+      <DefaultValue>Tenant</DefaultValue>
+      <Value>$(SqlCmdVar__18)</Value>
+    </SqlCmdVariable>
     <SqlCmdVariable Include="Version">
-      <DefaultValue>6.4.3</DefaultValue>
+      <DefaultValue>6.4.4</DefaultValue>
       <Value>$(SqlCmdVar__17)</Value>
     </SqlCmdVariable>
   </ItemGroup>

--- a/local.dbaid.database/local.dbaid.database.sqlproj
+++ b/local.dbaid.database/local.dbaid.database.sqlproj
@@ -242,6 +242,7 @@
     <Build Include="Database\Procedure\check\check_loginfailures.sql" />
     <Build Include="Database\Table\dbo_config_login_failures.sql" />
     <Build Include="Database\Function\dbo_get_instance_version.sql" />
+    <Build Include="Database\Procedure\check\check_inventory.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Database\Script.PostDeployment.sql" />

--- a/local.dbaid.database/local.dbaid.database.sqlproj
+++ b/local.dbaid.database/local.dbaid.database.sqlproj
@@ -84,6 +84,7 @@
     <FileAlignment>8192</FileAlignment>
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
     <SuppressTSqlWarnings>71502,70001,71562</SuppressTSqlWarnings>
+    <SqlTargetName>dbaid_debug</SqlTargetName>
   </PropertyGroup>
   <!-- VS10 without SP1 will not have VisualStudioVersion set, so do that here -->
   <PropertyGroup />

--- a/server.dbaid.extractor/Properties/AssemblyInfo.cs
+++ b/server.dbaid.extractor/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.3")]
+[assembly: AssemblyVersion("6.4.4")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/server.dbaid.keygen/Properties/AssemblyInfo.cs
+++ b/server.dbaid.keygen/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.3")]
+[assembly: AssemblyVersion("6.4.4")]
 //[assembly: AssemblyFileVersion("1.0.*")]


### PR DESCRIPTION
- Incremented version to 6.4.4.
- Added 3-part naming to [check].[backup].
- Modified [check].[backup] output to include TENANT_NAME, Instance name, database name, last full/differential backup date, last backup type, and state (OK/WARN/CRIT) for ALL databases, not just those that missed backup. This is for backup verification in DOME.
- Modified DEFAULT_ALWAYSON_ROLE value from CRITICAL to WARNING in [dbo].[static_parameters].
- Added TENANT_NAME to [dbo].[static_parameters].
- Added backup/restore of [dbo].[static_parameters] table for upgrades.
- Delimited $(DatabaseName) variable in upgrade backup table create/cleanup.
- Updated version showing in deployment PowerShell script.
- Added Tenant variable in deployment PowerShell script.
- Update [chart].[capacity] to output values as bytes instead of MB. This allows using Checkmk combined charts to map space used against disk space (which comes in as bytes).
- Update [chart].[capacity_combined] to output values as bytes instead of MB. This allows using Checkmk combined charts to map space used against disk space (which comes in as bytes).
- Update comments to use /* */ instead of --
- Update section to remove incompatible stored proc if deploying to SQL 2008.
- Add note for future enhancement for deployment script - different types of Checkmk plugin script.
- Set new SQLCMD variable.
- Update build version in SQLCMD variable.
- Set initial [default_state_alert] for [dbo].[config_job] from value in [dbo].[static_parameters] instead of being hard-coded.
- Set Client_name [parametervalue] in [deprecated].[tbparameters] from value in [dbo].[static_parameters] instead of being hard-coded.
- Remove duplicated backup/restore statements for [dbo].[static_parameters].
- Adjusted default parameters in checkmk plugin VBS & PowerShell scripts (to facilitate string replacement used in deployment script).
- Updated deployment PowerShell script, primarily to enable choice of Checkmk plugin to deploy.