### PR TITLE
#6.4.5

### DIFF
--- a/dbaid.common/Properties/AssemblyInfo.cs
+++ b/dbaid.common/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.4")]
+[assembly: AssemblyVersion("6.4.5")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/dbaid.common/dbaid.common.csproj
+++ b/dbaid.common/dbaid.common.csproj
@@ -62,6 +62,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/local.dbaid.checkmk/Properties/AssemblyInfo.cs
+++ b/local.dbaid.checkmk/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.4")]
+[assembly: AssemblyVersion("6.4.5")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -127,13 +127,13 @@ try {
     }
 
     <#  Get list of procedures to run for checks. All should be in the [checkmk] schema.  #>
-    $Query.CommandText = "SELECT [proc]=QUOTENAME(SCHEMA_NAME([schema_id])) + N'.' + QUOTENAME([name]) FROM [sys].[objects] WHERE [type] = 'P' AND SCHEMA_NAME([schema_id]) = 'check'"
+    $Query.CommandText = "EXEC [control].[check]"
     $DataSet = New-Object System.Data.DataSet
     $QueryResult = New-Object System.Data.SqlClient.SqlDataAdapter $Query
     $QueryResult.Fill($DataSet) | Out-Null
     $CheckProcedureList = $DataSet.Tables[0]
     
-    $Query.CommandText = "SELECT [proc]=QUOTENAME(SCHEMA_NAME([schema_id])) + N'.' + QUOTENAME([name]) FROM [sys].[objects] WHERE [type] = 'P' AND SCHEMA_NAME([schema_id]) = 'chart'"
+    $Query.CommandText = "EXEC [control].[chart]"
     $DataSet = New-Object System.Data.DataSet
     $QueryResult = New-Object System.Data.SqlClient.SqlDataAdapter $Query
     $QueryResult.Fill($DataSet) | Out-Null
@@ -173,7 +173,7 @@ try {
 
     <#  Process each check procedure in the [checkmk] schema.  #>
     foreach ($ckproc in $CheckProcedureList) {
-        $procname = ($ckproc.proc)
+        $procname = ($ckproc.cmd)
 
         <#  Pull part of procedure name to use in Checkmk service name.  #>
         $ServiceName = $procname.Substring($procname.IndexOf('.') + 2).Replace(']','')
@@ -228,7 +228,7 @@ try {
 
     <#  Process each chart procedure in the [checkmk] schema.  #>
     foreach ($ctproc in $ChartProcedureList) {
-        $procname = $ctproc.proc
+        $procname = $ctproc.cmd
 
         <#  Variables to manage pnp chart data. Initialize for each row of data being processed (i.e. per procedure call).  #>
         [string]$pnpData = ""

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-    DBAid Version 6.4.4
+    DBAid Version 6.4.5
     This script is for use as a Checkmk plugin. It requires minimum PowerShell 4.0.
     
 .DESCRIPTION

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -3,7 +3,7 @@ Sub Main()
     ' GNU GENERAL PUBLIC LICENSE
     ' Version 3, 29 June 2007
     
-    ' DBAid Version 6.4.4
+    ' DBAid Version 6.4.5
     ' define list of instances to connect to. Array elements should take the form of "MachineName" or "MachineName\InstanceName" (default & named instances respectively) where MachineName can be the hostname or IP address of the server . Optionally, add ",<TCPPort>".
     Dim v_SQLInstances
     v_SQLInstances = Array("localhost")

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -82,13 +82,13 @@ Sub Main()
         End If
 
         ' Refresh check configuration (i.e. to pick up any new jobs or databases added since last check).
-        v_SQL_Query = "SELECT [proc]=QUOTENAME(SCHEMA_NAME([schema_id])) + N'.' + QUOTENAME([name]) FROM [" & v_DBAid_Database & "].[sys].[objects] WHERE [type] = 'P' AND SCHEMA_NAME([schema_id]) = 'maintenance' AND [name] LIKE N'check_config%'"
+        v_SQL_Query = "SELECT [proc]=QUOTENAME(SCHEMA_NAME([schema_id])) + N'.' + QUOTENAME([name]) FROM [sys].[objects] WHERE [type] = 'P' AND SCHEMA_NAME([schema_id]) = 'maintenance' AND [name] LIKE N'check_config%'"
         v_RecordSet.Open v_SQL_Query, v_SQL_Conn, 0, 1
         If v_RecordSet.EOF Then
             WScript.Echo "3 mssql_" & v_InstanceName & " - Error occurred refreshing check configuration."
         Else
             Do While (Not v_RecordSet.EOF)
-                v_SQLChecks_Query = "EXEC [" & v_DBAid_Database & "]." & v_RecordSet.Fields.Item("proc")
+                v_SQLChecks_Query = "EXEC " & v_RecordSet.Fields.Item("proc")
                 ' using Conn.Execute method here rather than RecordSet.Open because the inventory procedures don't return a recordset; they just refresh configuration metadata
                 v_SQL_Conn.Execute(v_SQLChecks_Query)
                 v_RecordSet.MoveNext
@@ -118,7 +118,7 @@ Sub Main()
 
 
         ' get list of check procedures to loop through
-        v_SQL_Query = "SELECT [proc]=QUOTENAME(SCHEMA_NAME([schema_id])) + N'.' + QUOTENAME([name]) FROM [" & v_DBAid_Database & "].[sys].[objects] WHERE [type] = 'P' AND SCHEMA_NAME([schema_id]) = 'check'"
+        v_SQL_Query = "EXEC [control].[check]"
         v_RecordSet.Open v_SQL_Query, v_SQL_Conn, 0, 1
         If v_RecordSet.EOF Then
             WScript.Echo "3 mssql_" & v_InstanceName & " - Error occurred looping through checks."
@@ -127,8 +127,8 @@ Sub Main()
                 ' this loop executes each procedure in the [check] schema
                 v_SQLChecks_Message = ""
                 v_SQLChecks_Count = 0
-                v_SQLChecks_CheckName = Replace(Mid(v_RecordSet.Fields.Item("proc"), 10), "]", "") ' gets procedure name sans schema & [] characters. E.g., final output is mssql_Instance_ValueFromThisVariablev_SQLChecks_CheckName
-                v_SQLChecks_Query = "EXEC [" & v_DBAid_Database & "]." & v_RecordSet.Fields.Item("proc")
+                v_SQLChecks_CheckName = Replace(Mid(v_RecordSet.Fields.Item("cmd"), 10), "]", "") ' gets procedure name sans schema & [] characters. E.g., final output is mssql_Instance_ValueFromThisVariablev_SQLChecks_CheckName
+                v_SQLChecks_Query = "EXEC " & v_RecordSet.Fields.Item("cmd")
                 v_SQLChecks_RecordSet.Open v_SQLChecks_Query, v_SQL_Conn, 0, 1
                 v_SQLChecks_StateCheck = v_SQLChecks_RecordSet.Fields.Item("state")
                 v_SQLChecks_IsMultiRow = 0
@@ -142,7 +142,7 @@ Sub Main()
                     Case Else v_SQLChecks_Status = "3"
                 End Select
 
-				If (v_RecordSet.Fields.Item("proc") = "[check].[backup]") Or (v_RecordSet.Fields.Item("proc") = "[check].[inventory]") Then
+				If (v_RecordSet.Fields.Item("cmd") = "[check].[backup]") Or (v_RecordSet.Fields.Item("cmd") = "[check].[inventory]") Then
 					v_SQLChecks_IsMultiRow = 1
 				Else
 					v_SQLChecks_IsMultiRow = 0
@@ -186,7 +186,7 @@ Sub Main()
 
 
         ' get list of chart procedures to loop through
-        v_SQL_Query = "SELECT [proc]=QUOTENAME(SCHEMA_NAME([schema_id])) + N'.' + QUOTENAME([name]) FROM [" & v_DBAid_Database & "].[sys].[objects] WHERE [type] = 'P' AND SCHEMA_NAME([schema_id]) = 'chart'"
+        v_SQL_Query = "EXEC [control].[chart]"
         v_RecordSet.Open v_SQL_Query, v_SQL_Conn, 0, 1
         If v_RecordSet.EOF Then
             WScript.Echo "3 mssql_" & v_InstanceName & " - Error occurred looping through charts."
@@ -199,8 +199,8 @@ Sub Main()
                 v_SQLChecks_StateCheck = ""
                 v_SQLChecks_Status = 0
                 v_SQLChecks_Message = ""
-                v_SQLChecks_CheckName = Replace(Mid(v_RecordSet.Fields.Item("proc"), 10), "]", "") ' gets procedure name sans schema & [] characters. E.g., final output is mssql_Instance_ValueFromThisVariablev_SQLChecks_CheckName
-                v_SQLChecks_Query = "EXEC [" & v_DBAid_Database & "]." & v_RecordSet.Fields.Item("proc")
+                v_SQLChecks_CheckName = Replace(Mid(v_RecordSet.Fields.Item("cmd"), 10), "]", "") ' gets procedure name sans schema & [] characters. E.g., final output is mssql_Instance_ValueFromThisVariablev_SQLChecks_CheckName
+                v_SQLChecks_Query = "EXEC " & v_RecordSet.Fields.Item("cmd")
                 v_SQLChecks_RecordSet.Open v_SQLChecks_Query, v_SQL_Conn, 0, 1
                 Do While (Not v_SQLChecks_RecordSet.EOF)
                     ' this loop manages the multiple rows of chart data

--- a/local.dbaid.collector/Properties/AssemblyInfo.cs
+++ b/local.dbaid.collector/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.4")]
+[assembly: AssemblyVersion("6.4.5")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.configg/Properties/AssemblyInfo.cs
+++ b/local.dbaid.configg/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.4")]
+[assembly: AssemblyVersion("6.4.5")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Backup.sql
+++ b/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Backup.sql
@@ -7,76 +7,81 @@ Version 3, 29 June 2007
 CREATE PROCEDURE [deprecated].[Backup]
 WITH ENCRYPTION
 AS
-SET NOCOUNT ON;
+BEGIN
+	SET NOCOUNT ON;
 
-EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
+	EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
 
-DECLARE @client varchar(128)
-DECLARE @dbname VARCHAR(200)
+	DECLARE @client VARCHAR(128);
+	DECLARE @dbname VARCHAR(200);
 
-select @client = replace(replace(replace(CAST(SERVERPROPERTY('ServerName') as sysname)+[setting],'@','_'),'.','_'),'\','#')  
-FROM [deprecated].[tbparameters] where [parametername] = 'Client_domain'
+	SELECT @client = REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('ServerName') AS SYSNAME)+[setting],'@','_'),'.','_'),'\','#')  
+	FROM [deprecated].[tbparameters] 
+	WHERE [parametername] = 'Client_domain';
 
--- Table for storing results
-DECLARE @max_backup_dates TABLE ([DB_Name] nvarchar(255),[Start_Date] datetime)
+	-- Table for storing results
+	DECLARE @max_backup_dates TABLE ([DB_Name] NVARCHAR(255),[Start_Date] DATETIME);
 
-DECLARE @restoredbs TABLE ([DB_Name] nvarchar(255))
+	DECLARE @restoredbs TABLE ([DB_Name] NVARCHAR(255));
 
-insert @max_backup_dates
-SELECT CAST(database_name AS VARCHAR(255)) AS [DB_Name], 
-MAX(backup_start_date) AS [Start_Date] 
-FROM msdb.dbo.backupset  
-WHERE type = 'D' and [server_name] = CAST(SERVERPROPERTY('SERVERNAME') as sysname) --> GB 21/07/2009
-GROUP BY database_name
-ORDER BY database_name ASC
+	INSERT @max_backup_dates
+		SELECT CAST([database_name] AS VARCHAR(255)) AS [DB_Name], 
+		MAX([backup_start_date]) AS [Start_Date] 
+		FROM [msdb].[dbo].[backupset]
+		WHERE [type] = 'D' 
+		  AND [server_name] = CAST(SERVERPROPERTY('SERVERNAME') AS SYSNAME) --> GB 21/07/2009
+		GROUP BY [database_name]
+		ORDER BY [database_name] ASC;
 
-insert @restoredbs
-select distinct destination_database_name from msdb.dbo.restorehistory
-where restore_date >= DATEADD(dd, -1, getdate())
-and restore_type = 'D'
+	INSERT @restoredbs
+	SELECT DISTINCT [destination_database_name]
+	FROM [msdb].[dbo].[restorehistory]
+	WHERE [restore_date] >= DATEADD(dd, -1, GETDATE())
+	  AND [restore_type] = 'D';
 
-SELECT @client AS [Servername]
-	,ISNULL([db].[name],[mbd].[DB_Name]) AS [DatabaseName]
-	,ISNULL([Start_Date],'') AS [Date]
-	,CASE WHEN ([db].[crdate] > DATEADD(DAY, -1, GETDATE())) THEN 'New database'  --Database less than a day old
-		WHEN ([rh].[DB_Name] IS NOT NULL) and [tbpr].[setting] IS NULL THEN 'Restored' --Database was restored and not excluded from report.
-		WHEN ([rh].[DB_Name] IS NOT NULL) and [tbpr].[setting] = 1 THEN 'Exclude from restored database report' --Database was restored and excluded from report.
-		WHEN [tbp].[setting] = 0 OR [LS].[secondary_database] IS NOT NULL OR DATABASEPROPERTYEX([db].[name],'Status') = N'RESTORING' THEN 'Backup not required' --Covering log shipped and readonly databases.
-		WHEN DATABASEPROPERTYEX([db].[name],'Updateability') = N'READ_ONLY' THEN 'Read only database' --Read only database.
-		WHEN DATABASEPROPERTYEX([db].[name],'IsInStandBy') = 1 THEN 'Standby database' --Standby database.
-		WHEN DATABASEPROPERTYEX([db].[name],'Status') = N'OFFLINE' AND ([tbpo].[status] <> 1 OR [tbpo].[status] IS NULL) THEN 'IsOffline database' --Off line database.
-		WHEN DATABASEPROPERTYEX([db].[name],'Status') = N'OFFLINE' AND [tbpo].[status] = 1 THEN 'OK' --Ignore offline database if "excluded_from_Monitoring_DBName" is set in [deprecated].[tbparameters].
-		WHEN ([mbd].[DB_Name] IS NULL AND [db].[crdate] < DATEADD(DAY, -1, GETDATE())) THEN 'Never backed up' --Database has not backup date and is over a day old
-		WHEN ([db].[name] IS NULL) THEN 'Deleted' -- The database does not exsist in the sysdatabase table
-		WHEN ([Start_Date] >= GETDATE() - ISNULL(CONVERT(INT, [tbp].[setting]), 1)) THEN 'OK' -- The backup is not older than the retention period set in the tbparameter table
-		WHEN ([Start_Date] < GETDATE() - ISNULL(CONVERT(INT, [tbp].[setting]), 1)) THEN 'Backup Due' -- Backup older than than the retention period set in the tbparameter table.
-		ELSE '****' -- Catch all
-		END AS [Status]
-	,GETDATE() AS [checkdate] -- Date of the check
-FROM [master].[dbo].[sysdatabases] [db]
-	FULL OUTER JOIN @max_backup_dates [mbd] 
-		ON db.[name] = mbd.[DB_Name] COLLATE database_default
-	LEFT JOIN [deprecated].[tbparameters] [tbp]
-		ON db.[name] = [tbp].[parametername] COLLATE database_default
-			AND [tbp].[comments] LIKE 'Database Backup Frequency (Days)'
-	LEFT JOIN @restoredbs [rh]
-		ON [db].[name] = [rh].[DB_Name] COLLATE database_default
-	LEFT JOIN [msdb].[dbo].[log_shipping_monitor_secondary] [LS]
-		ON [db].[name] = [LS].[secondary_database] COLLATE database_default
-	LEFT JOIN [deprecated].[tbparameters] [tbpr] 
-		ON [db].[name] = [tbpr].[parametername] COLLATE database_default
-			AND [tbpr].[comments] like 'Exclude from restored database report'
-	LEFT JOIN [deprecated].[tbparameters] [tbpo] 
-		ON [db].[name] = [tbpo].[setting] COLLATE database_default
-			AND [tbpo].[parametername] LIKE 'excluded_from_Monitoring_DBName'
-WHERE NOT([db].[name] IS NULL AND [Start_Date] < GETDATE() - (ISNULL(CONVERT(INT, [tbp].[setting]), 1) + 1)) -- Remove all that were deleted over a day ago.
-	OR [db].[name] LIKE 'tempdb'
-ORDER BY [Status]
-	,[Start_Date] DESC
+	SELECT @client AS [Servername]
+		,ISNULL([db].[name],[mbd].[DB_Name]) AS [DatabaseName]
+		,ISNULL([Start_Date],'') AS [Date]
+		,CASE 
+			WHEN ([db].[crdate] > DATEADD(DAY, -1, GETDATE())) THEN 'New database'  --Database less than a day old
+			WHEN ([rh].[DB_Name] IS NOT NULL) AND [tbpr].[setting] IS NULL THEN 'Restored' --Database was restored and not excluded from report.
+			WHEN ([rh].[DB_Name] IS NOT NULL) AND [tbpr].[setting] = 1 THEN 'Exclude from restored database report' --Database was restored and excluded from report.
+			WHEN [tbp].[setting] = 0 OR [LS].[secondary_database] IS NOT NULL OR DATABASEPROPERTYEX([db].[name],'Status') = N'RESTORING' THEN 'Backup not required' --Covering log shipped and readonly databases.
+			WHEN DATABASEPROPERTYEX([db].[name],'Updateability') = N'READ_ONLY' THEN 'Read only database' --Read only database.
+			WHEN DATABASEPROPERTYEX([db].[name],'IsInStandBy') = 1 THEN 'Standby database' --Standby database.
+			WHEN DATABASEPROPERTYEX([db].[name],'Status') = N'OFFLINE' AND ([tbpo].[status] <> 1 OR [tbpo].[status] IS NULL) THEN 'IsOffline database' --Off line database.
+			WHEN DATABASEPROPERTYEX([db].[name],'Status') = N'OFFLINE' AND [tbpo].[status] = 1 THEN 'OK' --Ignore offline database if "excluded_from_Monitoring_DBName" is set in [deprecated].[tbparameters].
+			WHEN ([mbd].[DB_Name] IS NULL AND [db].[crdate] < DATEADD(DAY, -1, GETDATE())) THEN 'Never backed up' --Database has not backup date and is over a day old
+			WHEN ([db].[name] IS NULL) THEN 'Deleted' -- The database does not exsist in the sysdatabase table
+			WHEN ([Start_Date] >= GETDATE() - ISNULL(CONVERT(INT, [tbp].[setting]), 1)) THEN 'OK' -- The backup is not older than the retention period set in the tbparameter table
+			WHEN ([Start_Date] < GETDATE() - ISNULL(CONVERT(INT, [tbp].[setting]), 1)) THEN 'Backup Due' -- Backup older than than the retention period set in the tbparameter table.
+			ELSE '****' -- Catch all
+			END AS [Status]
+		,GETDATE() AS [checkdate] -- Date of the check
+	FROM [master].[dbo].[sysdatabases] [db]
+		FULL OUTER JOIN @max_backup_dates [mbd] 
+			ON db.[name] = mbd.[DB_Name] COLLATE database_default
+		LEFT JOIN [deprecated].[tbparameters] [tbp]
+			ON db.[name] = [tbp].[parametername] COLLATE database_default
+				AND [tbp].[comments] LIKE 'Database Backup Frequency (Days)'
+		LEFT JOIN @restoredbs [rh]
+			ON [db].[name] = [rh].[DB_Name] COLLATE database_default
+		LEFT JOIN [msdb].[dbo].[log_shipping_monitor_secondary] [LS]
+			ON [db].[name] = [LS].[secondary_database] COLLATE database_default
+		LEFT JOIN [deprecated].[tbparameters] [tbpr] 
+			ON [db].[name] = [tbpr].[parametername] COLLATE database_default
+				AND [tbpr].[comments] like 'Exclude from restored database report'
+		LEFT JOIN [deprecated].[tbparameters] [tbpo] 
+			ON [db].[name] = [tbpo].[setting] COLLATE database_default
+				AND [tbpo].[parametername] LIKE 'excluded_from_Monitoring_DBName'
+	WHERE NOT ([db].[name] IS NULL AND [Start_Date] < GETDATE() - (ISNULL(CONVERT(INT, [tbp].[setting]), 1) + 1)) -- Remove all that were deleted over a day ago.
+	   OR [db].[name] LIKE 'tempdb'
+	ORDER BY [Status]
+		,[Start_Date] DESC;
 
-IF (SELECT [value] FROM [dbo].[static_parameters] WHERE [name] = 'PROGRAM_NAME') = PROGRAM_NAME()
+	IF (SELECT [value] FROM [dbo].[static_parameters] WHERE [name] = 'PROGRAM_NAME') = PROGRAM_NAME()
 			UPDATE [dbo].[procedure] SET [last_execution_datetime] = GETDATE() WHERE [procedure_id] = @@PROCID;
 
-REVERT;
-
+	REVERT;
+END
 GO

--- a/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Databases.sql
+++ b/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Databases.sql
@@ -12,23 +12,23 @@ BEGIN
 
     EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
 
-    DECLARE @client varchar(128);
+    DECLARE @client VARCHAR(128);
 
-    SELECT @client = REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Servername') AS varchar(128)) + [setting], '@', '_'), '.', '_'), '\', '#')
+    SELECT @client = REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Servername') AS VARCHAR(128)) + [setting], '@', '_'), '.', '_'), '\', '#')
     FROM [$(DatabaseName)].[deprecated].[tbparameters] 
     WHERE [parametername] = 'Client_domain';
 
     SELECT @client AS [Client]
             ,GETDATE() AS [Checkdate]
             ,db.[name]
-            ,CAST(ROUND(SUM(CAST([size] AS bigint))/128.00, 2) AS NUMERIC(20,2)) AS [size]
+            ,CAST(ROUND(SUM(CAST([size] AS BIGINT))/128.00, 2) AS NUMERIC(20,2)) AS [size]
             ,ISNULL(SUSER_SNAME(db.[owner_sid]), '~~UNKNOWN~~') AS [owner]
             ,db.[database_id] AS [dbid]
             ,db.[create_date] AS [Created]
-            ,'Status =' + CONVERT(sysname, db.[state_desc]) 
+            ,'Status =' + CONVERT(SYSNAME, db.[state_desc]) 
                 + '| Updateability=' + CASE db.[is_read_only] WHEN 0 THEN 'READ_WRITE' ELSE 'READ_ONLY' END 
-                + '| Recovery=' + CONVERT(sysname, db.[recovery_model_desc] )
-                + '| Collation=' + CONVERT(sysname, ISNULL(db.[collation_name], CONVERT(sysname, SERVERPROPERTY('Collation')))) COLLATE DATABASE_DEFAULT AS [Status]
+                + '| Recovery=' + CONVERT(SYSNAME, db.[recovery_model_desc] )
+                + '| Collation=' + CONVERT(SYSNAME, ISNULL(db.[collation_name], CONVERT(SYSNAME, SERVERPROPERTY('Collation')))) COLLATE DATABASE_DEFAULT AS [Status]
             ,db.[compatibility_level] AS [Compatailiity_level]
     FROM sys.databases db 
       INNER JOIN sys.master_files mf ON mf.database_id = db.database_id

--- a/local.dbaid.database/Database/Procedure/Deprecated/deprecated_ErrorLog.sql
+++ b/local.dbaid.database/Database/Procedure/Deprecated/deprecated_ErrorLog.sql
@@ -7,107 +7,121 @@ Version 3, 29 June 2007
 CREATE PROCEDURE [deprecated].[ErrorLog]
 WITH ENCRYPTION
 AS
+BEGIN
+	SET NOCOUNT ON;
 
-SET NOCOUNT ON;
+	EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
 
-EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
+	DECLARE @mindate DATETIME;
+	Declare @client VARCHAR(128)
+	DECLARE @last_execute DATETIME;
+	DECLARE @report_datetime DATETIME;
+	DECLARE @enumerrorlogs TABLE ([archive] INT, [date] NVARCHAR(25), [file_size_byte] BIGINT);
+	DECLARE @lognum INT;
 
-DECLARE @mindate DATETIME;
-Declare @client varchar(128)
-DECLARE @last_execute DATETIME;
-DECLARE @report_datetime DATETIME;
-DECLARE @enumerrorlogs TABLE ([archive] INT, [date] NVARCHAR(25), [file_size_byte] BIGINT);
-DECLARE @lognum INT;
+	SELECT @client = REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('ServerName') AS VARCHAR(128)) + setting, '@', '_'), '.', '_'), '\', '#')  
+	FROM [deprecated].[tbparameters] 
+	WHERE parametername = 'Client_domain';
 
-select @client = replace(replace(replace(CAST(serverproperty('ServerName') as varchar(128))+setting,'@','_'),'.','_'),'\','#')  from [deprecated].[tbparameters] where parametername = 'Client_domain'
+	SET @last_execute = DATEADD(day,-1,GETDATE());
 
-SET @last_execute=DATEADD(day,-1,GETDATE());
+	--table to hold the errorlog entries
+	CREATE TABLE #errlog
+		(
+			[date_time] DATETIME,
+			[ProcessInfo] VARCHAR(50),
+			[err] VARCHAR(MAX),
+			[controw] TINYINT,
+			[countrow] INT IDENTITY(1,1)
+		);
 
---table to hold the errorlog entries
-CREATE TABLE #errlog
-	(
-		date_time datetime,
-		ProcessInfo varchar(50),
-		err varchar(MAX),
-		controw tinyint,
-		countrow int identity(1,1)
-	)
+	CREATE TABLE #errfound
+		(
+			[date_time] DATETIME,
+			[ProcessInfo] VARCHAR(50),
+			[message] VARCHAR(MAX),
+			[countrow] INT
+		);
 
-create table #errfound
-	(
-		date_time datetime,
-		ProcessInfo varchar(50),
-		message varchar(MAX),
-		countrow int
-	)
+	SET @report_datetime = GETDATE();
 
-SET @report_datetime = GETDATE();
--- @lognum variable for the number of errorlogs to review
-INSERT INTO @enumerrorlogs EXEC [master].[dbo].[xp_enumerrorlogs];
+	-- @lognum variable for the number of errorlogs to review
+	INSERT INTO @enumerrorlogs 
+		EXEC [master].[dbo].[xp_enumerrorlogs];
 
-SET @mindate = GETDATE()
+	SET @mindate = GETDATE();
 
-/* Insert error log messages */
-DECLARE curse CURSOR FAST_FORWARD FOR SELECT [archive] FROM @enumerrorlogs ORDER BY [date] DESC;
-OPEN curse;
-FETCH NEXT FROM curse INTO @lognum;
+	/* Insert error log messages */
+	DECLARE curse CURSOR FAST_FORWARD FOR SELECT [archive] FROM @enumerrorlogs ORDER BY [date] DESC;
+	OPEN curse;
+	FETCH NEXT FROM curse INTO @lognum;
 
-	WHILE (@@FETCH_STATUS = 0)
-	BEGIN
-		INSERT INTO #errlog(date_time, ProcessInfo, err)
-			EXEC [master].[dbo].[xp_readerrorlog] @lognum, 1, NULL, NULL, @last_execute, @report_datetime;
-
-		IF (@@ROWCOUNT = 0)
+		WHILE (@@FETCH_STATUS = 0)
 		BEGIN
-			BREAK;
-		END
+			INSERT INTO #errlog([date_time], [ProcessInfo], [err])
+				EXEC [master].[dbo].[xp_readerrorlog] @lognum, 1, NULL, NULL, @last_execute, @report_datetime;
 
-		FETCH NEXT FROM curse INTO @lognum;
-	END;
+			IF (@@ROWCOUNT = 0)
+			BEGIN
+				BREAK;
+			END
 
-CLOSE curse;
-DEALLOCATE curse;
+			FETCH NEXT FROM curse INTO @lognum;
+		END;
 
---display only the entries of the day in question.
-insert #errfound
-select date_time,ProcessInfo, replace(replace(replace(err,',',''), Char(10),'|'),Char(13),'') as 'Message',  countrow from #errlog
-where [date_time] >= @last_execute
-and (err like '%error%' or err like '%failed%')
-and (err not like '%found 0 errors and repaired 0 errors%' and err not like '%LOG\ERRORLOG%' and err not like '%without errors%' )
--- and err not like '%The SQL Network Interface%'
-order by err
+	CLOSE curse;
+	DEALLOCATE curse;
 
---Collect the Error message second row.
-insert #errfound
-Select el.date_time as 'Date',el.ProcessInfo, replace(replace(replace(el.err,',',''), Char(10),'|'),Char(13),'') as 'Message', el.countrow from #errlog el join #errfound ef on (el.countrow = ef.countrow +1 )
-where ef.message like '%Error:%Severity:%State:%'
-and (el.err not like '%error%'and el.err not like '%failed%') --make sure there are no duplicate rows.
+	--display only the entries of the day in question.
+	INSERT #errfound
+		SELECT [date_time]
+				,[ProcessInfo]
+				,REPLACE(REPLACE(REPLACE([err],',',''), CHAR(10),'|'), CHAR(13),'') AS 'Message'
+				,[countrow]
+		FROM #errlog
+		WHERE [date_time] >= @last_execute
+		  AND ([err] LIKE '%error%' OR [err] LIKE '%failed%')
+		  AND ([err] NOT LIKE '%found 0 errors and repaired 0 errors%' AND [err ] NOT LIKE '%LOG\ERRORLOG%' AND [err] NOT LIKE '%without errors%')
+		-- and err not like '%The SQL Network Interface%'
+		ORDER BY [err];
 
---Display the errors.
-if (select count(*) from #errfound) > 0
-begin
-	select [date_time]
-		,[ProcessInfo]
-		,@client AS [servername]
-		,[message] 
-	from #errfound
-	order by [date_time] desc
-end
-else
-  begin
---this will need to be changed as the number of columns is not correct
-    SELECT GETDATE() AS [date_time]
-		,'' AS 'ProcessInfo'
-		,@client AS [servername]
-		,'There are no error log messages' AS [message]
-  end
---drop the table to tidy up
-drop table #errlog
-drop table #errfound
+	--Collect the Error message second row.
+	INSERT #errfound
+	SELECT el.[date_time] AS 'Date'
+			,el.[ProcessInfo]
+			,REPLACE(REPLACE(REPLACE(el.[err], ',', ''), CHAR(10), '|'), CHAR(13), '') AS 'Message'
+			,el.[countrow] 
+	FROM #errlog el 
+		JOIN #errfound ef ON (el.[countrow] = ef.[countrow] + 1)
+	WHERE ef.[message] LIKE '%Error:%Severity:%State:%'
+	  AND (el.[err] NOT LIKE '%error%' AND el.[err] NOT LIKE '%failed%') --make sure there are no duplicate rows.
 
-IF (SELECT [value] FROM [dbo].[static_parameters] WHERE [name] = 'PROGRAM_NAME') = PROGRAM_NAME()
+	--Display the errors.
+	IF (SELECT COUNT(*) FROM #errfound) > 0
+	BEGIN
+		SELECT [date_time]
+			,[ProcessInfo]
+			,@client AS [servername]
+			,[message] 
+		FROM #errfound
+		ORDER BY [date_time] DESC;
+	END
+	ELSE
+	BEGIN
+	--this will need to be changed as the number of columns is not correct
+		SELECT GETDATE() AS [date_time]
+			,'' AS 'ProcessInfo'
+			,@client AS [servername]
+			,'There are no error log messages' AS [message];
+	END
+	
+	--drop the table to tidy up
+	DROP TABLE #errlog;
+	DROP TABLE #errfound;
+
+	IF (SELECT [value] FROM [dbo].[static_parameters] WHERE [name] = 'PROGRAM_NAME') = PROGRAM_NAME()
 			UPDATE [dbo].[procedure] SET [last_execution_datetime] = GETDATE() WHERE [procedure_id] = @@PROCID;
 
-REVERT;
-
+	REVERT;
+END
 GO

--- a/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Job.sql
+++ b/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Job.sql
@@ -7,70 +7,102 @@ Version 3, 29 June 2007
 CREATE PROCEDURE [deprecated].[Job]
 WITH ENCRYPTION
 AS
-SET NOCOUNT ON;
+BEGIN
+	SET NOCOUNT ON;
 
-EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
+	EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
 
-DECLARE @cmd NVARCHAR(3000)
+	DECLARE @cmd NVARCHAR(3000)
 
-DECLARE @name_Length INT, @step_ID_Length INT, @step_Name_Length INT,
- @message_Length INT,@status_Length INT, @servername_Length INT, @client nvarchar(128)
+	DECLARE @name_Length INT
+			,@step_ID_Length INT
+			,@step_Name_Length INT
+			,@message_Length INT
+			,@status_Length INT
+			,@servername_Length INT
+			,@client NVARCHAR(128);
  
-declare @job_tbl as table 
-(
-[Servername] nvarchar(128),
-[Job_Name] nvarchar(128),
-[Step_ID] INT,
-[Step_Name] nvarchar(128),
-[Step_Message] nvarchar(2048),
-[Status] nvarchar(20),
-[Date] nvarchar(10),
-[Time] nvarchar(10)
-)
+	DECLARE @job_tbl AS TABLE 
+		(
+			[Servername] NVARCHAR(128),
+			[Job_Name] NVARCHAR(128),
+			[Step_ID] INT,
+			[Step_Name] NVARCHAR(128),
+			[Step_Message] NVARCHAR(2048),
+			[Status] NVARCHAR(20),
+			[Date] NVARCHAR(10),
+			[Time] NVARCHAR(10)
+		);
 
-select @client = replace(replace(replace(CAST(serverproperty('ServerName') as varchar(128))+[setting],'@','_'),'.','_'),'\','#')  from [deprecated].[tbparameters] where [parametername] = 'Client_domain'
--- List of failed job steps
-insert @job_tbl
-SELECT @client,sj.name AS [Job_Name], jh.step_id  AS [Step_ID], jh.step_name  AS [Step_Name], substring(jh.message,1,2048) AS [Step_Message],
-  case jh.run_status
-	when 0 then 'Failed'
-	when 2 then 'Retry'
-	when 3 then 'Cancelled'
-  	else 'In progress'
-  end as 'Status',
-  substring(right('00000000'+ convert(varchar(8),jh.run_date),8),7,2)  +'/'+ substring(right('00000000'+  convert(varchar(8),jh.run_date),8),5,2) +'/'+ left(right('00000000'+  convert(varchar(8),jh.run_date),8),4) as 'Date',
-  left(right('000000'+  convert(varchar(6),jh.run_time),6),2) +':'+ substring(right('000000'+  convert(varchar(6),jh.run_time),6),3,2) +':'+ substring(right('000000'+  convert(varchar(6),jh.run_time),6),5,2) as 'Time'
-FROM msdb..sysjobhistory jh join msdb..sysjobs sj on jh.job_id = sj.job_id
-WHERE jh.run_status not in (1,4) AND step_id <> 0
-AND [msdb].[dbo].[agent_datetime]([jh].[run_date], [jh].[run_time]) >= DATEADD(HOUR, 6, DATEADD(DAY, DATEDIFF(DAY, 0, GETDATE()), 0))
+	SELECT @client = REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('ServerName') AS VARCHAR(128)) + [setting], '@', '_'), '.', '_'), '\', '#')
+	FROM [deprecated].[tbparameters] 
+	WHERE [parametername] = 'Client_domain';
+	
+	-- List of failed job steps
+	INSERT @job_tbl
+		SELECT @client
+				,sj.[name] AS [Job_Name]
+				,jh.[step_id] AS [Step_ID]
+				,jh.[step_name] AS [Step_Name]
+				,SUBSTRING(jh.[message], 1, 2048) AS [Step_Message]
+				,CASE jh.[run_status]
+					WHEN 0 THEN 'Failed'
+					WHEN 2 THEN 'Retry'
+					WHEN 3 THEN 'Cancelled'
+  					ELSE 'In progress'
+				END AS 'Status'
+				,SUBSTRING(RIGHT('00000000' + CONVERT(VARCHAR(8), jh.[run_date]), 8), 7, 2) + '/' + SUBSTRING(RIGHT('00000000' + CONVERT(VARCHAR(8), jh.[run_date]), 8), 5, 2) + '/' + LEFT(RIGHT('00000000' + CONVERT(VARCHAR(8), jh.[run_date]), 8), 4) AS 'Date'
+				,LEFT(RIGHT('000000' + CONVERT(VARCHAR(6), jh.[run_time]), 6), 2) + ':' + SUBSTRING(RIGHT('000000' + CONVERT(VARCHAR(6), jh.[run_time]), 6), 3, 2) + ':' + SUBSTRING(RIGHT('000000' + CONVERT(VARCHAR(6), jh.[run_time]), 6), 5, 2) AS 'Time'
+		FROM [msdb].[dbo].[sysjobhistory] jh 
+			JOIN [msdb].[dbo].[sysjobs] sj ON jh.[job_id] = sj.[job_id]
+		WHERE jh.[run_status] NOT IN (1, 4)
+		  AND step_id <> 0
+		  AND [msdb].[dbo].[agent_datetime](jh.[run_date], jh.[run_time]) >= DATEADD(HOUR, 6, DATEADD(DAY, DATEDIFF(DAY, 0, GETDATE()), 0));
 
--- List of failed jobs if failed on the initalization step (0)
-insert @job_tbl
-SELECT @client,sj.name AS [Job_Name], jh.step_id  AS [Step_ID], jh.step_name AS [Step_Name], jh.message AS [Step_Message] ,
- case jh.run_status
-		when 0 then 'Failed' when 2 then 'Retry' when 3 then 'Cancelled' else 'In progress' end as 'Status'
-		, substring(right('00000000'+ convert(varchar(8),jh.run_date),8),7,2)  +'/'+ substring(right('00000000'+  convert(varchar(8),jh.run_date),8),5,2) +'/'+ left(right('00000000'+  convert(varchar(8),jh.run_date),8),4) as 'Date'
-		, left(right('000000'+  convert(varchar(6),jh.run_time),6),2) +':'+ substring(right('000000'+  convert(varchar(6),jh.run_time),6),3,2) +':'+ substring(right('000000'+  convert(varchar(6),jh.run_time),6),5,2) as 'Time'
-		FROM msdb..sysjobhistory jh join msdb..sysjobs sj on jh.job_id = sj.job_id
-		left outer join  @job_tbl jt on (sj.name = jt.[Job_Name] COLLATE database_default) 
-		WHERE jh.run_status <> 1
-		AND jh.step_id = 0
-		and jt.[Job_Name] is null
-		AND [msdb].[dbo].[agent_datetime]([jh].[run_date], [jh].[run_time]) >= DATEADD(HOUR, 6, DATEADD(DAY, DATEDIFF(DAY, 0, DATEADD(DAY,-1,GETDATE())),0))
+	-- List of failed jobs if failed on the initalization step (0)
+	INSERT @job_tbl
+		SELECT @client
+				,sj.[name] AS [Job_Name]
+				,jh.[step_id] AS [Step_ID]
+				,jh.[step_name] AS [Step_Name]
+				,jh.[message] AS [Step_Message]
+				,CASE jh.[run_status]
+					WHEN 0 THEN 'Failed' 
+					WHEN 2 THEN 'Retry' 
+					WHEN 3 THEN 'Cancelled' 
+					ELSE 'In progress' 
+				END AS 'Status'
+				,SUBSTRING(RIGHT('00000000' + CONVERT(VARCHAR(8), jh.[run_date]), 8), 7, 2) + '/' + SUBSTRING(RIGHT('00000000' + CONVERT(VARCHAR(8), jh.[run_date]), 8), 5, 2) + '/' + LEFT(RIGHT('00000000' + CONVERT(VARCHAR(8), jh.[run_date]), 8), 4) AS 'Date'
+				,LEFT(RIGHT('000000' + CONVERT(VARCHAR(6), jh.[run_time]), 6), 2) + ':' + SUBSTRING(RIGHT('000000' + CONVERT(VARCHAR(6), jh.[run_time]), 6), 3, 2) + ':' + SUBSTRING(RIGHT('000000' + CONVERT(VARCHAR(6), jh.[run_time]), 6), 5, 2) AS 'Time'
+		FROM [msdb].[dbo].[sysjobhistory] jh 
+			JOIN [msdb].[dbo].[sysjobs] sj ON jh.[job_id] = sj.[job_id]
+			LEFT OUTER JOIN @job_tbl jt ON (sj.[name] = jt.[Job_Name] COLLATE database_default) 
+		WHERE jh.[run_status] <> 1
+		  AND jh.[step_id] = 0
+		  AND jt.[Job_Name] IS NULL
+		  AND [msdb].[dbo].[agent_datetime]([jh].[run_date], [jh].[run_time]) >= DATEADD(HOUR, 6, DATEADD(DAY, DATEDIFF(DAY, 0, DATEADD(DAY,-1,GETDATE())),0));
 
---check to see if there are any jobs to report.
-IF (select count(1) from @job_tbl) = 0 
- begin
-  	--Print 'Postive check.'
-	Insert @job_tbl ([Servername],[Job_Name],[Step_ID],[Step_Name],[Step_Message],[Status],[Date],[Time])
-	Values(@client,'',0,'','There are no failed jobs','',CONVERT(VARCHAR(10), DATEADD(DAY, DATEDIFF(DAY, 0, GETDATE()), 0),103), CONVERT(VARCHAR(8), GETDATE(), 108))
-END
+	--check to see if there are any jobs to report.
+	IF (SELECT COUNT(1) FROM @job_tbl) = 0 
+	BEGIN
+  		--Print 'Postive check.'
+		INSERT @job_tbl ([Servername], [Job_Name], [Step_ID], [Step_Name], [Step_Message], [Status], [Date], [Time])
+		VALUES (@client, '', 0, '', 'There are no failed jobs', '', CONVERT(VARCHAR(10), DATEADD(DAY, DATEDIFF(DAY, 0, GETDATE()), 0), 103), CONVERT(VARCHAR(8), GETDATE(), 108));
+	END
 
-Select [Servername] ,replace([Job_Name],'"','''') as [Job_Name] ,[Step_ID],replace([Step_Name],'"','''') ,[Status] ,[Date] ,[Time],replace(replace(replace([Step_Message],'"',''''), Char(13),'|'),char(10),'') as [Message] From @job_tbl
+	SELECT [Servername] 
+			,REPLACE([Job_Name], '"', '''') AS [Job_Name] 
+			,[Step_ID]
+			,REPLACE([Step_Name], '"', '''')
+			,[Status]
+			,[Date]
+			,[Time]
+			,REPLACE(REPLACE(REPLACE([Step_Message], '"', ''''), CHAR(13), '|'), CHAR(10), '') AS [Message] 
+	FROM @job_tbl;
 
 	IF (SELECT [value] FROM [dbo].[static_parameters] WHERE [name] = 'PROGRAM_NAME') = PROGRAM_NAME()
 		UPDATE [dbo].[procedure] SET [last_execution_datetime] = GETDATE() WHERE [procedure_id] = @@PROCID;
 
-REVERT;
-
+	REVERT;
+END
 GO

--- a/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Version.sql
+++ b/local.dbaid.database/Database/Procedure/Deprecated/deprecated_Version.sql
@@ -7,22 +7,27 @@ Version 3, 29 June 2007
 CREATE PROCEDURE [deprecated].[Version]
 WITH ENCRYPTION
 AS
+BEGIN
+	SET NOCOUNT ON;
 
-SET NOCOUNT ON;
+	EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
 
-EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
+	DECLARE @sender VARCHAR(228);
+	DECLARE @subjectname VARCHAR(128);
 
-Declare @sender varchar(228)
-Declare @subjectname varchar(128)
+	SELECT @sender = CAST(SERVERPROPERTY('Servername') AS VARCHAR(128)) + [setting] 
+	FROM [deprecated].[tbparameters] 
+	WHERE [parametername] = 'Client_domain';
 
-select @sender = CAST(serverproperty('servername') as varchar(128)) + [setting] from [deprecated].[tbparameters] where [parametername] = 'Client_domain'
-select @subjectname = replace(replace(replace (@sender, '@','_'),'.','_'),'\','#')
+	SELECT @subjectname = REPLACE(REPLACE(REPLACE(@sender, '@','_'),'.','_'),'\','#');
 
-select @subjectname as 'Servername',getdate() as 'Checkdate',@@version as 'Version'
+	SELECT @subjectname AS 'Servername'
+			,getdate() AS 'Checkdate'
+			,@@version AS 'Version';
 
 	IF (SELECT [value] FROM [dbo].[static_parameters] WHERE [name] = 'PROGRAM_NAME') = PROGRAM_NAME()
 		UPDATE [dbo].[procedure] SET [last_execution_datetime] = GETDATE() WHERE [procedure_id] = @@PROCID;
 
-REVERT;
-
+	REVERT;
+END
 GO

--- a/local.dbaid.database/Database/Procedure/check/check_alwayson.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_alwayson.sql
@@ -15,7 +15,6 @@ BEGIN
 
 	IF SERVERPROPERTY('IsHadrEnabled') = 1
 	BEGIN
-
 		EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
 
 		INSERT INTO @check

--- a/local.dbaid.database/Database/Procedure/check/check_backup.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_backup.sql
@@ -8,7 +8,7 @@ CREATE PROCEDURE [check].[backup]
 WITH ENCRYPTION
 AS
 BEGIN
-SET NOCOUNT ON;
+	SET NOCOUNT ON;
 
 	DECLARE @check TABLE([message] NVARCHAR(4000)
 						,[state] NVARCHAR(8));
@@ -17,9 +17,9 @@ SET NOCOUNT ON;
 	DECLARE @not_backup INT;
 	DECLARE @tenant NVARCHAR(256);
   
-  SELECT @tenant = CAST([value] AS nvarchar(256)) FROM [$(DatabaseName)].[dbo].[static_parameters] WHERE [name] = N'TENANT_NAME';
+	SELECT @tenant = CAST([value] AS nvarchar(256)) FROM [$(DatabaseName)].[dbo].[static_parameters] WHERE [name] = N'TENANT_NAME';
 
-  EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
+	EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
 
 	IF SERVERPROPERTY('IsHadrEnabled') = 1
 	BEGIN

--- a/local.dbaid.database/Database/Procedure/check/check_checkdb.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_checkdb.sql
@@ -32,14 +32,14 @@ BEGIN
 
 	EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
 
-		EXECUTE [dbo].[foreachdb] N'USE [?];
-									INSERT #dbccinfo
-										(ParentObject, 
-										Object, 
-										Field, 
-										Value)
-									EXEC (''DBCC DBINFO() WITH TABLERESULTS, NO_INFOMSGS'');
-									UPDATE #dbccinfo SET [DbName] = N''?'' WHERE [DbName] IS NULL;';
+	EXECUTE [dbo].[foreachdb] N'USE [?];
+								INSERT #dbccinfo
+									(ParentObject, 
+									Object, 
+									Field, 
+									Value)
+								EXEC (''DBCC DBINFO() WITH TABLERESULTS, NO_INFOMSGS'');
+								UPDATE #dbccinfo SET [DbName] = N''?'' WHERE [DbName] IS NULL;';
 
 	;WITH [CheckDB] AS
 	(
@@ -76,13 +76,13 @@ BEGIN
 			AND [D].[is_enabled] = 1
 		ORDER BY [CheckDB].[DbName]
 
-		IF (SELECT COUNT(*) FROM @check) < 1
-			INSERT INTO @check 
-			VALUES(CAST(@dbcheckdb AS NVARCHAR(10)) + N' database(s) monitored, ' + CAST(@dbnotcheckdb AS NVARCHAR(10)) + N' database(s) opted-out'
-				,N'NA');
+	IF (SELECT COUNT(*) FROM @check) < 1
+		INSERT INTO @check 
+		VALUES(CAST(@dbcheckdb AS NVARCHAR(10)) + N' database(s) monitored, ' + CAST(@dbnotcheckdb AS NVARCHAR(10)) + N' database(s) opted-out'
+			,N'NA');
 
-		SELECT [message], [state] 
-		FROM @check
+	SELECT [message], [state] 
+	FROM @check
 
-		REVERT;
-	END
+	REVERT;
+END

--- a/local.dbaid.database/Database/Procedure/check/check_database.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_database.sql
@@ -59,5 +59,5 @@ BEGIN
 
 		SELECT [message], [state] FROM @check
 
-		REVERT;
+	REVERT;
 END

--- a/local.dbaid.database/Database/Procedure/check/check_loginfailures.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_loginfailures.sql
@@ -9,6 +9,9 @@ WITH ENCRYPTION
 AS
 BEGIN
     SET NOCOUNT ON;
+
+	EXECUTE AS LOGIN = N'$(DatabaseName)_sa';
+
     DECLARE @ExtendedEventsSessionName sysname = N'_dbaid_login_failures',
             @StartTime datetimeoffset,
             @EndTime datetimeoffset,
@@ -151,6 +154,8 @@ BEGIN
       UNION
       SELECT * FROM [TotalLoginFailures];
     END
+
+	REVERT;
 
 END
 GO

--- a/local.dbaid.database/local.dbaid.database.sqlproj
+++ b/local.dbaid.database/local.dbaid.database.sqlproj
@@ -287,7 +287,7 @@
       <Value>$(SqlCmdVar__18)</Value>
     </SqlCmdVariable>
     <SqlCmdVariable Include="Version">
-      <DefaultValue>6.4.4</DefaultValue>
+      <DefaultValue>6.4.5</DefaultValue>
       <Value>$(SqlCmdVar__17)</Value>
     </SqlCmdVariable>
   </ItemGroup>

--- a/server.dbaid.extractor/Properties/AssemblyInfo.cs
+++ b/server.dbaid.extractor/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.4")]
+[assembly: AssemblyVersion("6.4.5")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/server.dbaid.keygen/Properties/AssemblyInfo.cs
+++ b/server.dbaid.keygen/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.4")]
+[assembly: AssemblyVersion("6.4.5")]
 //[assembly: AssemblyFileVersion("1.0.*")]


### PR DESCRIPTION
* Fixed code to enumerate check & chart procedures to run (now honours [is_enabled] setting in [dbo].[procedure] table again).
* Altered all stored procedure calls to use two-part naming.
* Updated version to 6.4.5.
* Tidied up code & layout for several items.
* Removed option to deploy dbaid.checkmk.exe from PowerShell deployment script.
* Removed EOF check for enumeration of procedures from [chart] and [check] schemas. This check was to try and handle problems with the ADODB recordset, but is being tripped if all procedures are excluded via updates to [dbo].[procedure]. If need be, will later see if we can manage an EOF due to issue vs. valid empty recordset.