### PR TITLE
#6.4.6

### DIFF
--- a/dbaid.common/Properties/AssemblyInfo.cs
+++ b/dbaid.common/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.5")]
+[assembly: AssemblyVersion("6.4.6")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.checkmk/Properties/AssemblyInfo.cs
+++ b/local.dbaid.checkmk/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.5")]
+[assembly: AssemblyVersion("6.4.6")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -329,6 +329,11 @@ try {
             $State = "OK"
         }
 
+        <# Checkmk 2.x doesn't like : or / characters in output (something to do with Python 3)
+           We could replace them in the stored procedure code, but doing it here gives more flexibility/ability to change characters used.
+        #>
+        (($StatusDetails).Replace(':', '_')).Replace('/', '_')
+
         <#  Write output for Checkmk agent to consume.  #>
         Write-Host "$Status mssql_$($ServiceName)_$($InstanceName) $StatusDetails $State"
     }

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -332,7 +332,7 @@ try {
         <# Checkmk 2.x doesn't like : or / characters in output (something to do with Python 3)
            We could replace them in the stored procedure code, but doing it here gives more flexibility/ability to change characters used.
         #>
-        (($StatusDetails).Replace(':', '_')).Replace('/', '_')
+        $StatusDetails = (($StatusDetails).Replace(':', '_')).Replace('/', '_')
 
         <#  Write output for Checkmk agent to consume.  #>
         Write-Host "$Status mssql_$($ServiceName)_$($InstanceName) $StatusDetails $State"

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-    DBAid Version 6.4.5
+    DBAid Version 6.4.6
     This script is for use as a Checkmk plugin. It requires minimum PowerShell 4.0.
     
 .DESCRIPTION

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -3,7 +3,7 @@ Sub Main()
     ' GNU GENERAL PUBLIC LICENSE
     ' Version 3, 29 June 2007
     
-    ' DBAid Version 6.4.5
+    ' DBAid Version 6.4.6
     ' define list of instances to connect to. Array elements should take the form of "MachineName" or "MachineName\InstanceName" (default & named instances respectively) where MachineName can be the hostname or IP address of the server . Optionally, add ",<TCPPort>".
     Dim v_SQLInstances
     v_SQLInstances = Array("localhost")

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -248,12 +248,12 @@ Sub Main()
                             v_SQLCharts_AlertValue = Split(v_SQLChecks_pnpData, "=")
                             v_SQLCharts_AlertValue(0) = Replace(v_SQLCharts_AlertValue(0), "'", "")
 
-                            v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "CRITICAL - " & v_SQLCharts_AlertValue & "; "
+                            v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "CRITICAL - " & v_SQLCharts_AlertValue(0) & "; "
                             v_SQLChecks_Status = "2"
                         ElseIf CDbl(v_SQLCharts_Val) >= CDbl(v_SQLCharts_Warn) AND v_SQLChecks_Status < 2 Then
                             v_SQLCharts_AlertValue = Split(v_SQLChecks_pnpData, "=")
                             v_SQLCharts_AlertValue(0) = Replace(v_SQLCharts_AlertValue(0), "'", "")
-                            v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "WARNING - " & v_SQLCharts_AlertValue & "; "
+                            v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "WARNING - " & v_SQLCharts_AlertValue(0) & "; "
                             v_SQLChecks_Status = "1"
                         End If
                     End If
@@ -261,12 +261,12 @@ Sub Main()
                     If CDbl(v_SQLCharts_Val) <= CDbl(v_SQLCharts_Crit) Then
                         v_SQLCharts_AlertValue = Split(v_SQLChecks_pnpData, "=")
                         v_SQLCharts_AlertValue(0) = Replace(v_SQLCharts_AlertValue(0), "'", "")
-                        v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "CRITICAL - " & v_SQLCharts_AlertValue & "; "
+                        v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "CRITICAL - " & v_SQLCharts_AlertValue(0) & "; "
                         v_SQLChecks_Status = "2"
                     ElseIf CDbl(v_SQLCharts_Val) <= CDbl(v_SQLCharts_Warn) AND v_SQLChecks_Status < 2 Then
                         v_SQLCharts_AlertValue = Split(v_SQLChecks_pnpData, "=")
                         v_SQLCharts_AlertValue(0) = Replace(v_SQLCharts_AlertValue(0), "'", "")
-                        v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "WARNING - " & v_SQLCharts_AlertValue & "; "
+                        v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "WARNING - " & v_SQLCharts_AlertValue(0) & "; "
                         v_SQLChecks_Status = "1"
                     End If
                 End If 

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -37,6 +37,8 @@ Sub Main()
     Set v_WSH_Shell = CreateObject("WScript.Shell")
 
     ' build base connection string; instance name will be appended
+    ' NB - SQLOLEDB IS DEPRECATED. IT MAY WORK FOR OLDER MACHINES BUT FOR NEWER MACHINES, REPLACE SQLOLEDB.1 WITH MSOLEDBSQL
+    '      YOU WILL NEED TO DO IT WHEN YOU GET THIS ERROR: Microsoft OLE DB Provider for SQL Server: [DBNETLIB][ConnectionOpen (SECDoClientHandshake()).]SSL Security error.
     v_DBAid_Database = "_dbaid"
     v_DB_Connect_String_Base = "Provider=SQLOLEDB.1;Initial Catalog=" & v_DBAid_Database & ";Integrated Security=SSPI;Application Name=Checkmk;Data Source="
 

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -286,6 +286,10 @@ Sub Main()
 				v_SQLChecks_StateCheck = "OK"
 			End If
 				
+            ' Checkmk 2.x doesn't like : or / characters in output (something to do with Python 3)
+            ' We could replace them in the stored procedure code, but doing it here gives more flexibility/ability to change characters used.
+            v_SQLChecks_Message = Replace(Replace(v_SQLChecks_Message, ":", "_"), "/", "_")
+
             ' Write output for Checkmk agent to consume.
             WScript.Echo v_SQLChecks_Status & " mssql_" & v_SQLChecks_CheckName & "_" & v_InstanceName & " " & v_SQLChecks_Message & " " & v_SQLChecks_StateCheck
 

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -248,12 +248,12 @@ Sub Main()
                             v_SQLCharts_AlertValue = Split(v_SQLChecks_pnpData, "=")
                             v_SQLCharts_AlertValue(0) = Replace(v_SQLCharts_AlertValue(0), "'", "")
 
-                            v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "CRITICAL - " & v_SQLCharts_AlertValue(0) & "; "
+                            v_SQLChecks_StateCheck = v_SQLChecks_StateCheck & "CRITICAL - " & v_SQLCharts_AlertValue(0) & "; "
                             v_SQLChecks_Status = "2"
                         ElseIf CDbl(v_SQLCharts_Val) >= CDbl(v_SQLCharts_Warn) AND v_SQLChecks_Status < 2 Then
                             v_SQLCharts_AlertValue = Split(v_SQLChecks_pnpData, "=")
                             v_SQLCharts_AlertValue(0) = Replace(v_SQLCharts_AlertValue(0), "'", "")
-                            v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "WARNING - " & v_SQLCharts_AlertValue(0) & "; "
+                            v_SQLChecks_StateCheck = v_SQLChecks_StateCheck & "WARNING - " & v_SQLCharts_AlertValue(0) & "; "
                             v_SQLChecks_Status = "1"
                         End If
                     End If
@@ -261,12 +261,12 @@ Sub Main()
                     If CDbl(v_SQLCharts_Val) <= CDbl(v_SQLCharts_Crit) Then
                         v_SQLCharts_AlertValue = Split(v_SQLChecks_pnpData, "=")
                         v_SQLCharts_AlertValue(0) = Replace(v_SQLCharts_AlertValue(0), "'", "")
-                        v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "CRITICAL - " & v_SQLCharts_AlertValue(0) & "; "
+                        v_SQLChecks_StateCheck = v_SQLChecks_StateCheck & "CRITICAL - " & v_SQLCharts_AlertValue(0) & "; "
                         v_SQLChecks_Status = "2"
                     ElseIf CDbl(v_SQLCharts_Val) <= CDbl(v_SQLCharts_Warn) AND v_SQLChecks_Status < 2 Then
                         v_SQLCharts_AlertValue = Split(v_SQLChecks_pnpData, "=")
                         v_SQLCharts_AlertValue(0) = Replace(v_SQLCharts_AlertValue(0), "'", "")
-                        v_SQLChecks_StateCheck = v_SQLChecks_StateCheck + "WARNING - " & v_SQLCharts_AlertValue(0) & "; "
+                        v_SQLChecks_StateCheck = v_SQLChecks_StateCheck & "WARNING - " & v_SQLCharts_AlertValue(0) & "; "
                         v_SQLChecks_Status = "1"
                     End If
                 End If 

--- a/local.dbaid.collector/Properties/AssemblyInfo.cs
+++ b/local.dbaid.collector/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.5")]
+[assembly: AssemblyVersion("6.4.6")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.configg/Properties/AssemblyInfo.cs
+++ b/local.dbaid.configg/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.5")]
+[assembly: AssemblyVersion("6.4.6")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.database/Database/Function/dbo_get_instance_version.sql
+++ b/local.dbaid.database/Database/Function/dbo_get_instance_version.sql
@@ -12,7 +12,7 @@ BEGIN
     SELECT @edition = CAST([value] AS sysname) 
            + N',' 
            + CAST(SERVERPROPERTY('MachineName') AS sysname) 
-           + N'\' 
+           + N'#' 
            + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER') 
            + N',Microsoft SQL Server '
            + CASE LEFT(CAST(SERVERPROPERTY('ProductVersion') AS sysname), 4)
@@ -24,9 +24,9 @@ BEGIN
                WHEN N'10.5' THEN N'2008 R2 '
                WHEN N'10.0' THEN N'2008 '
                WHEN N'9.0.' THEN N'2005 '
-               WHEN N'8.0.' THEN N'2000 '
+               WHEN N'8.00' THEN N'2000 '
              END
-           + REPLACE(REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Edition') AS sysname), N'(64-bit)', N'64-bit'), N': Core-based Licensing', N''), N'Edition', N''), N'  ', N' ')
+           + RTRIM(REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Edition') AS sysname), N': Core-based Licensing', N''), N'Edition', N''), N'  ', N' '))
            ,@patch_level = CAST(SERVERPROPERTY('ProductLevel') AS sysname) 
            + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductUpdateLevel') AS sysname), N'') 
            + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductBuildType') AS sysname), N'') + N',' 
@@ -37,9 +37,9 @@ BEGIN
         SELECT N'0 mssql_' 
                + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER') 
                + N' - ' 
-               + CASE RIGHT(@edition, 3)
-                   WHEN N'bit' THEN @edition
-                   ELSE @edition + N'32-bit'
+               + CASE RIGHT(@edition, 8)
+                   WHEN N'(64-bit)' THEN REPLACE(@edition, N' (64-bit)', N'')
+                   ELSE @edition + N' 32-bit'
                  END
                + N',' 
                + @patch_level;	

--- a/local.dbaid.database/Database/Procedure/check/check_backup.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_backup.sql
@@ -144,11 +144,15 @@ BEGIN
 			WHERE [D].[state] = 0
 				AND [D].[is_in_standby] = 0
 		)
+		/* Using # as separator for ServerName\InstanceName\DatabaseName as an instance or database with [lower case?] "n" as first character
+			 leads to a "\n" combination that Checkmk interprets as a newline character. Does not seem to be possible to escape this combination
+			 to stop it happening.
+		*/
 		INSERT INTO @check
 		SELECT @tenant
 				+ N',' + CAST(SERVERPROPERTY('MachineName') AS sysname) 
-				+ N'\' + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER')
-				+ N'\' + [D].[db_name]
+				+ N'#' + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER')
+				+ N'#' + [D].[db_name]
 				+ N',' + ISNULL(CONVERT(NVARCHAR(20), [B].[backup_finish_date], 23), N'1900-01-01')
 				+ N',' + CASE [type] WHEN 'D' THEN 'FULL' WHEN 'I' THEN 'DIFFERENTIAL' ELSE 'UNKNOWN' END
 				,[S].[state]

--- a/local.dbaid.database/Database/Procedure/check/check_inventory.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_inventory.sql
@@ -15,29 +15,17 @@ BEGIN
 	DECLARE @check TABLE([message] NVARCHAR(4000)
 						,[state] NVARCHAR(8));
 
+    /* Using # as separator for ServerName\InstanceName\DatabaseName as an instance or database with [lower case?] "n" as first character
+         leads to a "\n" combination that Checkmk interprets as a newline character. Does not seem to be possible to escape this combination
+         to stop it happening.
+    */
     INSERT INTO @check
     SELECT CAST(s.[value] AS sysname) 
             + N',' 
             + CAST(SERVERPROPERTY('MachineName') AS sysname) 
-            + N'\' 
+            + N'#' 
             + ISNULL(CAST(SERVERPROPERTY('InstanceName') AS sysname), N'MSSQLSERVER') 
-            + N'\' + D.[name]
-            + N',Microsoft SQL Server '
-            + CASE LEFT(CAST(SERVERPROPERTY('ProductVersion') AS sysname), 4)
-                WHEN N'15.0' THEN N'2019 '
-                WHEN N'14.0' THEN N'2017 '
-                WHEN N'13.0' THEN N'2016 '
-                WHEN N'12.0' THEN N'2014 '
-                WHEN N'11.0' THEN N'2012 '
-                WHEN N'10.5' THEN N'2008 R2 '
-                WHEN N'10.0' THEN N'2008 '
-                WHEN N'9.0.' THEN N'2005 '
-                WHEN N'8.0.' THEN N'2000 '
-            END
-            + REPLACE(REPLACE(REPLACE(REPLACE(CAST(SERVERPROPERTY('Edition') AS sysname), N'(64-bit)', N'64-bit'), N': Core-based Licensing', N''), N'Edition', N''), N'  ', N' ')
-            + N',' + CAST(SERVERPROPERTY('ProductLevel') AS sysname) 
-            + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductUpdateLevel') AS sysname), N'') 
-            + ISNULL(N'-' + CAST(SERVERPROPERTY('ProductBuildType') AS sysname), N'') 
+            + N'#' + D.[name]
             , N'OK'
     FROM [$(DatabaseName)].[dbo].[static_parameters] s, sys.databases D 
       INNER JOIN [$(DatabaseName)].[dbo].[config_database] c ON D.[database_id] = c.[database_id]

--- a/local.dbaid.database/deployDBAid.ps1
+++ b/local.dbaid.database/deployDBAid.ps1
@@ -3,7 +3,7 @@
 #
 # Expected source folder structure example:
 # 
-# C:\temp\DBAid-build-6.4.5
+# C:\temp\DBAid-build-6.4.6
 #        \check_mk
 #        \database
 #        \Datacom
@@ -19,14 +19,14 @@
 # set variables
 $deploy_collector = 1                        # deploy dbaid collector: 1 = Yes, 0 = No
 $deploy_configg = 1                          # deploy config genie: 1 = Yes, 0 = No
-# Choose one of the Checkmk deployment options below. NB - Executable is deprecated and will be removed in a future version.
-$deploy_checkmk_vbs = 0                      # deploy checkmk VBScript plugin: 1 = Yes, 0 = No
-$deploy_checkmk_ps1 = 1                      # deploy checkmk PowerShell plugin: 1 = Yes, 0 = No
+# Choose one of the Checkmk deployment options below. VBS is default as per advice at https://docs.checkmk.com/latest/en/dev_guidelines.html#_agent_plug_ins
+$deploy_checkmk_vbs = 1                      # deploy checkmk VBScript plugin: 1 = Yes, 0 = No
+$deploy_checkmk_ps1 = 0                      # deploy checkmk PowerShell plugin: 1 = Yes, 0 = No
 $hostname = $env:computername                # If this is a clustered SQL instance, change this to $hostname = "<VNN of SQL instance>"
 $SQLInstance = "MSSQLSERVER"                 # SQL instance to deploy to. MSSQLSERVER = default instance.
 $dbaid_db_name = "_dbaid"                    # Name of database to deploy dbaid to. Best if this is left as default of _dbaid
 $SourceRootFolder = "C:\temp"                # Folder in which source DBAid folder structure is in
-$DBAid_src = "$SourceRootFolder\DBAid-build-6.4.5" # Root folder for dbaid source files.
+$DBAid_src = "$SourceRootFolder\DBAid-build-6.4.6" # Root folder for dbaid source files.
 $dest_root = "C:"                            # Root drive to deploy dbaid executables to.
 
 $checkmk_svc = "NT AUTHORITY\SYSTEM"         # Service account to use for Checkmk plugin (should be same as Check_MK_Agent Windows service)

--- a/local.dbaid.database/local.dbaid.database.sqlproj
+++ b/local.dbaid.database/local.dbaid.database.sqlproj
@@ -26,7 +26,7 @@
     <EnableFullTextSearch>False</EnableFullTextSearch>
     <AllowSnapshotIsolation>False</AllowSnapshotIsolation>
     <ReadCommittedSnapshot>False</ReadCommittedSnapshot>
-    <DacVersion>6.4.3</DacVersion>
+    <DacVersion>6.4.6</DacVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -287,7 +287,7 @@
       <Value>$(SqlCmdVar__18)</Value>
     </SqlCmdVariable>
     <SqlCmdVariable Include="Version">
-      <DefaultValue>6.4.5</DefaultValue>
+      <DefaultValue>6.4.6</DefaultValue>
       <Value>$(SqlCmdVar__17)</Value>
     </SqlCmdVariable>
   </ItemGroup>

--- a/server.dbaid.extractor/Properties/AssemblyInfo.cs
+++ b/server.dbaid.extractor/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.5")]
+[assembly: AssemblyVersion("6.4.6")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/server.dbaid.keygen/Properties/AssemblyInfo.cs
+++ b/server.dbaid.keygen/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.5")]
+[assembly: AssemblyVersion("6.4.6")]
 //[assembly: AssemblyFileVersion("1.0.*")]


### PR DESCRIPTION
### General
This release requires:
 - Windows 2012 or higher.
 - SQL Server 2016 or higher (although most components will work with SQL 2012, SQL 2014).
 - .NET 4.x
 - PowerShell v4 or higher (if using Checkmk PowerShell plug-in).

### What's Changed
- Update version numbers to 6.4.6
- Make VBS Checkmk plugin the default for deployment script.
- Add missing array element reference for capacity string concatention statements (where used capacity tripped an alert threshold).Replace "+" with "&" for string concatenation statements (missed a few from last cleanup of such).
- Fixed issue where monitoring of backups on AG-enabled instances was returning old data format.
- Update get_instance_version to remove reference to 64-bit (it is assumed to be default these days).
- Update get_instance_version to replace server\instance separator "\\" with "#" (to avoid \n combination that Checkmk will interpret as newline character).
- Update get_instance_version to reflect actual version string snippet returned for SQL Server 2000.
- Added note re: use of SQLOLEDB.1 vs MSOLEDBSQL in dbaid-checkmk.vbs.

### Known Issues
There have been changes in Ola's solution that can cause errors when upgrading from versions of DBAid prior to 6.2.0:

* If a database has been explicitly excluded from backups and/or integrity checks and has since been deleted, the related job may fail. Other databases will be backed up/checked OK.
* The folder structure for database backups has changed. If you do not specify the @Directory parameter, and the default backup folder pulled from the registry is determined to have a default path (e.g. "%.MSSQLSERVER\MSSQL\Backup" or "%.INSTANCENAME\MSSQL\Backup"), subfolders for each database will be created directly under the "Backup" subfolder; a subfolder for [SERVERNAME[$INSTANCE]] will no longer be used\created. This may cause capacity issues after upgrading, depending on how you manage deletion of previous backups.