### PR TITLE
Resolve issues 73 and 74

### DIFF
--- a/dbaid.common/Properties/AssemblyInfo.cs
+++ b/dbaid.common/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.9")]
+[assembly: AssemblyVersion("6.5.0")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.checkmk/Properties/AssemblyInfo.cs
+++ b/local.dbaid.checkmk/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.9")]
+[assembly: AssemblyVersionAttribute("6.5.0")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.checkmk/dbaid-checkmk.ps1
+++ b/local.dbaid.checkmk/dbaid-checkmk.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-    DBAid Version 6.4.9
+    DBAid Version 6.5.0
     This script is for use as a Checkmk plugin. It requires minimum PowerShell 4.0.
     
 .DESCRIPTION
@@ -208,13 +208,21 @@ try {
         if ($IsMultiRow) {
             foreach ($ckrow in $DataSet.Tables[0].Rows) {
                 $StatusDetails = -join ($StatusDetails, $ckrow.message, "~")
-                $State = $ckrow.state
+                if ($State -eq 'OK' -or $State -eq '') {
+                    $State = $ckrow.state
+                    $Status = Switch($ckrow.state){ 'NA'{0} 'OK'{0} 'WARNING'{1} 'CRITICAL'{2} default{3}}
+                }
+                elseif ($State -eq 'WARNING' -and ($ckrow.state -eq 'CRITICAL')) { 
+                    $State = $ckrow.state
+                    $Status = Switch($ckrow.state){ 'NA'{0} 'OK'{0} 'WARNING'{1} 'CRITICAL'{2} default{3}}
+                }
             }
         }
         else {
             foreach ($ckrow in $DataSet.Tables[0].Rows) {
                 $StatusDetails = -join ($StatusDetails, $ckrow.message, ";\n ")
                 $State = $ckrow.state
+                $Status = Switch($ckrow.state){ 'NA'{0} 'OK'{0} 'WARNING'{1} 'CRITICAL'{2} default{3}}
             }
         }
 

--- a/local.dbaid.checkmk/dbaid-checkmk.vbs
+++ b/local.dbaid.checkmk/dbaid-checkmk.vbs
@@ -3,7 +3,7 @@ Sub Main()
     ' GNU GENERAL PUBLIC LICENSE
     ' Version 3, 29 June 2007
     
-    ' DBAid Version 6.4.9
+    ' DBAid Version 6.5.0
     ' define list of instances to connect to. Array elements should take the form of "MachineName" or "MachineName\InstanceName" (default & named instances respectively) where MachineName can be the hostname or IP address of the server . Optionally, add ",<TCPPort>".
     Dim v_SQLInstances
     v_SQLInstances = Array("localhost")
@@ -159,10 +159,37 @@ Sub Main()
                     ' NB - for backups & inventory, need to have data on one line otherwise it can't be pulled into DOME (only the first line comes through).  Use ~ as row delimiter.
                     If v_SQLChecks_IsMultiRow = 1 Then
                         v_SQLChecks_Message = v_SQLChecks_Message & v_SQLChecks_RecordSet.Fields.Item("message") & "~"
+                        If (v_SQLChecks_StateCheck = "OK" Or v_SQLChecks_StateCheck = "") Then
+                            v_SQLChecks_StateCheck = v_SQLChecks_RecordSet.Fields.Item("state")
+                            Select Case v_SQLChecks_StateCheck
+                                Case "NA" v_SQLChecks_Status = "0"
+                                Case "OK" v_SQLChecks_Status = "0"
+                                Case "WARNING" v_SQLChecks_Status = "1"
+                                Case "CRITICAL" v_SQLChecks_Status = "2"
+                                Case Else v_SQLChecks_Status = "3"
+                            End Select
+                        ElseIf (v_SQLChecks_StateCheck = "WARNING") And (v_SQLChecks_RecordSet.Fields.Item("state") = "CRITICAL") Then
+                            v_SQLChecks_StateCheck = v_SQLChecks_RecordSet.Fields.Item("state")
+                            Select Case v_SQLChecks_StateCheck
+                                Case "NA" v_SQLChecks_Status = "0"
+                                Case "OK" v_SQLChecks_Status = "0"
+                                Case "WARNING" v_SQLChecks_Status = "1"
+                                Case "CRITICAL" v_SQLChecks_Status = "2"
+                                Case Else v_SQLChecks_Status = "3"
+                            End Select
+                        End If
                         v_SQLChecks_Count = v_SQLChecks_Count + 1
                         v_SQLChecks_RecordSet.MoveNext
                     Else
                         v_SQLChecks_Message = v_SQLChecks_Message & v_SQLChecks_RecordSet.Fields.Item("message") & ";\n "
+                        v_SQLChecks_StateCheck = v_SQLChecks_RecordSet.Fields.Item("state")
+                        Select Case v_SQLChecks_StateCheck
+                            Case "NA" v_SQLChecks_Status = "0"
+                            Case "OK" v_SQLChecks_Status = "0"
+                            Case "WARNING" v_SQLChecks_Status = "1"
+                            Case "CRITICAL" v_SQLChecks_Status = "2"
+                            Case Else v_SQLChecks_Status = "3"
+                        End Select                    
                         v_SQLChecks_Count = v_SQLChecks_Count + 1
                         v_SQLChecks_RecordSet.MoveNext
                     End If

--- a/local.dbaid.collector/Properties/AssemblyInfo.cs
+++ b/local.dbaid.collector/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.9")]
+[assembly: AssemblyVersionAttribute("6.5.0")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.configg/Properties/AssemblyInfo.cs
+++ b/local.dbaid.configg/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.9")]
+[assembly: AssemblyVersionAttribute("6.5.0")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/local.dbaid.database/Database/Procedure/check/check_job.sql
+++ b/local.dbaid.database/Database/Procedure/check/check_job.sql
@@ -28,32 +28,32 @@ BEGIN
 	;WITH [jobset]
 	AS
 	(
-		SELECT ROW_NUMBER() OVER (PARTITION BY [J].[name] ORDER BY [H].[run_date] DESC, [H].[run_time] DESC) AS [row]
+		SELECT ROW_NUMBER() OVER (PARTITION BY [J].[name] ORDER BY [JS].[last_run_date] DESC, [JS].[last_run_time] DESC) AS [row]
 			,[J].[job_id]
 			,[J].[name]
-			,[H].[run_status]
+			,[JS].[last_run_outcome]
 		FROM [msdb].[dbo].[sysjobs] [J]
-			INNER JOIN [msdb].[dbo].[sysjobhistory] [H]
-				ON [J].[job_id] = [H].[job_id]
+			INNER JOIN [msdb].[dbo].[sysjobservers] [JS]
+				ON [J].[job_id] = [JS].[job_id]
 		WHERE [J].[enabled] = 1
-			AND [H].[step_id] = 0
 	)
 	INSERT INTO @check
 		SELECT N'job=' + QUOTENAME([J].[name]) COLLATE Database_Default
 				+ N'; state=' 
-				+ CASE [J].[run_status] 
+				+ CASE [J].[last_run_outcome] 
 					WHEN 0 THEN N'FAIL'
 					WHEN 1 THEN N'SUCCESS'
 					WHEN 2 THEN N'RETRY'
 					WHEN 3 THEN N'CANCEL'
+					WHEN 4 THEN N'IN PROGRESS'
 					ELSE N'UNKNOWN' END AS [message]
-			,CASE WHEN [J].[run_status] IN (0) THEN [C].[change_state_alert] ELSE 'OK' END AS [state]
+			,CASE WHEN [J].[last_run_outcome] IN (0) THEN [C].[change_state_alert] ELSE 'OK' END AS [state]
 		FROM [jobset] [J]
 			INNER JOIN [dbo].[config_job] [C]
 				ON [J].[job_id] = [C].[job_id]
 		WHERE [J].[row] = 1
 			AND [C].[is_enabled] = 1
-			AND [J].[run_status] = 0;
+	  AND [J].[last_run_outcome] = 0;
 
 	IF (SELECT COUNT(*) FROM @check) < 1
 		INSERT INTO @check 

--- a/local.dbaid.database/Properties/AssemblyInfo.cs
+++ b/local.dbaid.database/Properties/AssemblyInfo.cs
@@ -19,4 +19,4 @@
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("6.4.9")]
+[assembly: AssemblyVersion("6.5.0")]

--- a/local.dbaid.database/deployDBAid.ps1
+++ b/local.dbaid.database/deployDBAid.ps1
@@ -3,7 +3,7 @@
 #
 # Expected source folder structure example:
 # 
-# C:\temp\DBAid-build-6.4.9
+# C:\temp\DBAid-build-6.5.0
 #        \check_mk
 #        \database
 #        \Datacom
@@ -26,7 +26,7 @@ $hostname = $env:computername                # If this is a clustered SQL instan
 $SQLInstance = "MSSQLSERVER"                 # SQL instance to deploy to. MSSQLSERVER = default instance.
 $dbaid_db_name = "_dbaid"                    # Name of database to deploy dbaid to. Best if this is left as default of _dbaid
 $SourceRootFolder = "C:\temp"                # Folder in which source DBAid folder structure is in
-$DBAid_src = "$SourceRootFolder\DBAid-build-6.4.9" # Root folder for dbaid source files.
+$DBAid_src = "$SourceRootFolder\DBAid-build-6.5.0" # Root folder for dbaid source files.
 $dest_root = "C:"                            # Root drive to deploy dbaid executables to.
 
 $checkmk_svc = "NT AUTHORITY\SYSTEM"         # Service account to use for Checkmk plugin (should be same as Check_MK_Agent Windows service)

--- a/local.dbaid.database/local.dbaid.database.sqlproj
+++ b/local.dbaid.database/local.dbaid.database.sqlproj
@@ -26,7 +26,7 @@
     <EnableFullTextSearch>False</EnableFullTextSearch>
     <AllowSnapshotIsolation>False</AllowSnapshotIsolation>
     <ReadCommittedSnapshot>False</ReadCommittedSnapshot>
-    <DacVersion>6.4.6</DacVersion>
+    <DacVersion>6.5.0</DacVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -287,7 +287,7 @@
       <Value>$(SqlCmdVar__18)</Value>
     </SqlCmdVariable>
     <SqlCmdVariable Include="Version">
-      <DefaultValue>6.4.9</DefaultValue>
+      <DefaultValue>6.5.0</DefaultValue>
       <Value>$(SqlCmdVar__17)</Value>
     </SqlCmdVariable>
   </ItemGroup>

--- a/server.dbaid.extractor/Properties/AssemblyInfo.cs
+++ b/server.dbaid.extractor/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.9")]
+[assembly: AssemblyVersionAttribute("6.5.0")]
 //[assembly: AssemblyFileVersion("1.0.*")]

--- a/server.dbaid.keygen/Properties/AssemblyInfo.cs
+++ b/server.dbaid.keygen/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.4.9")]
+[assembly: AssemblyVersion("6.5.0")]
 //[assembly: AssemblyFileVersion("1.0.*")]


### PR DESCRIPTION
Updated code in [check].[job] to use sysjobservers rather than sysjobhistory for last job run status.

Updated code in PowerShell & VBS Checkmk plugin scripts to return correct status for database backups. Updated version number to 6.5.0.